### PR TITLE
Use i18n in active_admin.rb

### DIFF
--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -22,7 +22,7 @@ ActiveAdmin.setup do |config|
   config.namespace :admin do |admin|
     admin.build_menu do |menu|
       menu.add label: User.model_name.human(count: 2) do |submenu|
-        submenu.add label: 'Não alocados', 
+        submenu.add label: I18n.t('active_admin.resources.user.scopes.not_allocated'), 
                     url: '/admin/users?scope=not_allocated', 
                     priority: 2, 
                     if: proc { current_user.is_admin? }

--- a/config/locales/en/active_admin.yml
+++ b/config/locales/en/active_admin.yml
@@ -2,3 +2,7 @@ en:
   active_admin:
     admin_reset_password: 'An email with password reset instructions was sent'
     admin_reset_password_button: 'Send password reset email'
+    resources:
+      user:
+        scopes:
+          not_allocated: 'Not allocated'

--- a/config/locales/pt-BR/active_admin.yml
+++ b/config/locales/pt-BR/active_admin.yml
@@ -25,4 +25,4 @@ pt-BR:
     resources:
       user:
         scopes:
-          not_allocated: 'Não alocado'
+          not_allocated: 'Não alocados'

--- a/config/locales/pt-BR/pt-BR.yml
+++ b/config/locales/pt-BR/pt-BR.yml
@@ -21,7 +21,6 @@ pt-BR:
   english_evaluations: 'Avaliações de Inglês'
   not_evaluated: 'Não avaliado'
   not_allocated: 'Não alocado'
-  users_not_allocated: 'Não alocados'
   projects: 'Projetos'
   perfomance_evaluations: 'Avaliações de Desempenho'
   allocation: 'Alocação'


### PR DESCRIPTION
Added the translation string in the i18n resources and replaced the hardcoded label with a call to the rails I18N service.

Closes #3