### PR TITLE
Adds user's current allocation in navbar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,8 +43,13 @@ class ApplicationController < ActionController::Base
     @current_company ||= current_user.company
   end
 
+  def current_user
+    UserDecorator.decorate(super) unless super.nil?
+  end
+
   protected
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_in, keys: [:email, :password, :otp_attempt])
-    end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:email, :password, :otp_attempt])
+  end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -5,8 +5,13 @@ class UserDecorator < Draper::Decorator
 
   def current_allocation
     current_allocation = model.current_allocation
+
     if current_allocation.present?
-      h.link_to current_allocation.name, [:admin, current_allocation]
+      if h.current_user.is_admin?
+        h.link_to current_allocation.name, [:admin, current_allocation]
+      else
+        current_allocation.name
+      end
     else
       I18n.t('not_allocated')
     end

--- a/app/views/refills/_navigation.html.erb
+++ b/app/views/refills/_navigation.html.erb
@@ -25,9 +25,15 @@
 
         <div class="navbar-nav ml-auto nav-link">
           <%= link_to user_path do %>
-            <span>
-              <%= current_user.name %>
-            </span>
+            <div class="text-center">
+              <span>
+                <%= current_user.name %>
+              </span>
+              <br/>
+              <span>
+                <%= current_user.current_allocation %>
+              </span>
+            </div>
             <%= gravatar_for current_user, size: 40 %>
           <% end %>
           <%= link_to t('.logout'), destroy_user_session_path %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, :type => :controller do
+  controller do
+    def index
+      render json: { success: true }
+    end
+  end
+
+  describe 'when logged in' do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    it 'current user returns a user Decorator' do
+      get :index
+      expect(controller.current_user).to be_an_instance_of(UserDecorator)
+      expect(controller.current_user).to eq(user)
+    end
+  end
+end


### PR DESCRIPTION
Added the current allocation below the name of the user in the navbar.

Closes #5

![image](https://user-images.githubusercontent.com/45002716/133778831-ca57e283-933b-45da-8498-8afeec993c83.png)
