### PR TITLE
Improve single page forms

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
 @import 'deactivate_two_factor';
 @import 'pagination';
 @import 'show_user';
+@import 'form_container';
 
 $gray: #ededed;
 

--- a/app/assets/stylesheets/form_container.scss
+++ b/app/assets/stylesheets/form_container.scss
@@ -1,0 +1,16 @@
+#form-container {
+  display: flex;
+  justify-content: center;
+
+  .content {
+    width: calc(max(25%, 400px));
+  }
+
+  fieldset + fieldset {
+    margin-top: 10px;
+  }
+
+  fieldset:last-of-type {
+    margin-bottom: 20px;
+  }
+}

--- a/app/views/passwords/_form.html.erb
+++ b/app/views/passwords/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_for(user, url: url_path) do |f| %>
+
+  <fieldset>
+    <%= f.label 'Current Password' %>
+    <%= f.password_field :current_password, class: 'form-control'%>
+  </fieldset>
+
+  <fieldset>
+    <%= f.label 'Password' %>
+    <%= f.password_field :password, class: 'form-control' %>
+  </fieldset>
+
+  <fieldset>
+    <%= f.label 'Password Confirmation' %>
+    <%= f.password_field :password_confirmation, class: 'form-control' %>
+  </fieldset>
+
+  <div>
+    <%= link_to 'Cancel', edit_user_path, class: 'btn btn-secondary' %>
+    <%= f.submit('Update', { class: 'btn btn-primary' }) %>
+  </div>
+
+<% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,24 +1,6 @@
-<%= form_for(current_user, url: users_account_password_update_path) do |f| %>
-	<table border="0" cellspacing="8" cellpadding="8">
-    <tr>
-      <th><%= f.label 'Current Password' %></th>
-      <th><%= f.password_field :current_password, class: 'form-control'%></th>
-    </tr>
-		<tr>
-			<th><%= f.label 'Password' %></th>
-			<th><%= f.password_field :password, class: 'form-control' %></th>
-		</tr>
-		<tr>
-			<th><%= f.label 'Password Confirmation' %></th>
-			<th><%= f.password_field :password_confirmation, class: 'form-control' %></th>
-		</tr>
-    <tr>
-      <td colspan="2">
-        <div class="actions">
-          <%= link_to 'Cancel', edit_user_path, class: 'btn btn-secondary' %>
-          <%= f.submit('Update', { class: 'btn btn-primary' }) %>
-        </div>
-      </td>
-    </tr>
-	</table>
-<% end %>
+<div id="form-container">
+  <div class="content">
+    <h2>Edit Password</h2>
+    <%= render 'form', user: current_user, url_path: users_account_password_update_path %>
+  </div>
+</div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,23 +2,23 @@
 
   <%= render "shared/errors", messages: user.errors.full_messages %>
 
-  <div>
+  <fieldset>
     <%= f.label :name %>
-    <%= f.text_field :name %>
-  </div>
+    <%= f.text_field :name, class: 'form-control' %>
+  </fieldset>
 
-  <div>
+  <fieldset>
     <%= f.label :email %>
-    <%= f.email_field :email %>
-  </div>
-  
-  <div>
+    <%= f.email_field :email, class: 'form-control' %>
+  </fieldset>
+
+  <fieldset>
     <%= f.label :github %>
-    <%= f.text_field :github %>
-  </div>
+    <%= f.text_field :github, class: 'form-control' %>
+  </fieldset>
 
   <div>
-  <%= f.submit %>
+    <%= f.submit %>
   </div>
 
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,6 @@
-<div class="row">
-  <div class="col-lg-6">
-    <h2> Edit User </h2>
+<div id="form-container">
+  <div class="content">
+    <h2>Edit User</h2>
     <%= render 'form', user: current_user, url_path: user_path %>
   </div>
 </div>
-<br>


### PR DESCRIPTION
This PR addresses issues #10 and #11 

The idea behind this improvement is to make all "single page forms" share a single stylesheet, this is why I'm fixing both issues at the same time. The user update form and the password change now are centralized and have better spacing between elements. I also noticed that the user update form was not using the `form-control` class on its HTML fields, making the styling a bit different from other forms. 

The Form Container was also designed to be responsive, but since the rest of the page is not, there's not much I can do right now.

<details>
<summary>Screenshots</summary>

![localhost_5000_user_edit](https://user-images.githubusercontent.com/25598040/134211783-23789b33-e94a-489d-a293-3c8838574a7a.png)
![localhost_5000_users_account_password_edit](https://user-images.githubusercontent.com/25598040/134211792-1ceeed5c-8137-4598-a568-ec5c1f82b25e.png)
</details>