### PR TITLE
remove 'rails_12factor' from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,5 @@ group :development, :test do
 end
 
 group :production, :staging do
-  gem 'rails_12factor'
   gem 'passenger', '~> 6.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,11 +361,6 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.3.7)
       actionpack (= 6.0.3.7)
       activesupport (= 6.0.3.7)
@@ -573,7 +568,6 @@ DEPENDENCIES
   rails (~> 6.0.3.7)
   rails-controller-testing
   rails-i18n
-  rails_12factor
   ransack (~> 2.3)
   rollbar
   rqrcode


### PR DESCRIPTION
Removed rails_12factor from Gemfile and Gemfile.lock.
Closes #28 