### PR TITLE
Disable save button when no project is selected

### DIFF
--- a/app/javascript/packs/components/Form.js
+++ b/app/javascript/packs/components/Form.js
@@ -3,12 +3,14 @@ import Select from 'react-select2-wrapper';
 
 class Form extends React.Component{
   state = {
+    selectedProject: "",
     hasConfirmedOperation: false
   }
 
   render() {
     const { calendar: { selecteds } } = this.props;
     const isSelectedsEmpty = selecteds.isEmpty();
+    const isSaveButtonDisabled = isSelectedsEmpty || !!!this.state.selectedProject
 
     const projectsList = Projects.map((p) =>  {
       return {text: p[1], id: p[0]}
@@ -44,9 +46,11 @@ class Form extends React.Component{
             <div className="col select-container">
               <Select
                 ref="project"
+                value={this.state.selectedProject}
                 data={projectsList}
                 disabled={isSelectedsEmpty}
                 options={{ placeholder: 'Projeto' }}
+                onChange={(e) => this.handleProjectChange(e)}
               />
             </div>
             <div className="col">
@@ -90,7 +94,7 @@ class Form extends React.Component{
               </div>
             </div>
             <div className="col">
-              <input className="w-100" disabled={isSelectedsEmpty} type="submit" value="Salvar" />
+              <input className="w-100" disabled={isSaveButtonDisabled} type="submit" value="Salvar" />
             </div>
           </div>
         </div>
@@ -100,6 +104,12 @@ class Form extends React.Component{
 
   /* Removes the double confirmation prompt */
   componentDidUpdate() {
+    if (this.props.calendar.selecteds.size == 0) {
+      if (this.state.selectedProject) {
+        this.setState({ selectedProject: "" })
+      }
+    }
+
     if (this.state.hasConfirmedOperation) {
       this.handleSave();
       this.setState({ hasConfirmedOperation: false })
@@ -128,7 +138,7 @@ class Form extends React.Component{
       this.props.calendar.sheets,
       this.props.calendar.deleteds
     );
-    this.setState({ hasConfirmedOperation: true })
+    this.setState({ hasConfirmedOperation: true, selectedProject: "" })
   }
 
   handleErase() {
@@ -143,6 +153,10 @@ class Form extends React.Component{
 
   handleDeselect() {
     this.props.onDeselect();
+  }
+
+  handleProjectChange(e) {
+    this.setState({ selectedProject: e.currentTarget.value })
   }
 }
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -65,6 +65,12 @@ feature 'Punches Dashboard', js: true do
       click_on 'Salvar'
       expect(page).to have_content('Horas: 24')
     end
+
+    scenario 'When no project has been selected' do
+      visit '/dashboard/2018/02'
+      find('td.inner', text: '21').click
+      expect(page).to have_button('Salvar', disabled: true)
+    end
   end
 
   context 'When user do not have overtime allowed' do

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 feature 'Punches Dashboard', js: true do
   context 'When user has overtime allowed' do
     let!(:authed_user_with_overtime) { create_logged_in_user(allow_overtime: true) }
+    let!(:active_project) { create(:project, :active, company_id: authed_user_with_overtime.company_id) }
 
     scenario 'Calendar navigation' do
       visit '/dashboard/2014/12'
@@ -21,6 +22,8 @@ feature 'Punches Dashboard', js: true do
 
       find('td.inner', text: '10').click
       find('td.inner', text: '11').click
+      find('span.select2').click
+      find('li.select2-results__option').click
       click_on 'Salvar'
       expect(page).to have_content("Selecionado (0)")
 
@@ -35,6 +38,8 @@ feature 'Punches Dashboard', js: true do
 
       find('td.inner', text: '02').click
       find('td.inner', text: '15').click
+      find('span.select2').click
+      find('li.select2-results__option').click
       expect(page).to have_content("Selecionado (2)")
       click_on 'Salvar'
       expect(page).to have_content("Selecionado (0)")
@@ -54,6 +59,8 @@ feature 'Punches Dashboard', js: true do
       end
 
       find('td.inner', text: '21').click
+      find('span.select2').click
+      find('li.select2-results__option').click
       expect(page).to have_content('Selecionado (3)')
       click_on 'Salvar'
       expect(page).to have_content('Horas: 24')
@@ -62,12 +69,15 @@ feature 'Punches Dashboard', js: true do
 
   context 'When user do not have overtime allowed' do
     let!(:authed_user_without_overtime) { create_logged_in_user }
+    let!(:active_project) { create(:project, :active, company_id: authed_user_without_overtime.company_id) }
 
     scenario 'Insert punches on holiday' do
       visit 'dashboard/2013/11'
 
       find('td.inner', text: '02').click
       find('td.inner', text: '03').click
+      find('span.select2').click
+      find('li.select2-results__option').click
       expect(page).to have_content("Selecionado (1)")
       click_on 'Salvar'
       expect(page).to have_content("Selecionado (0)")


### PR DESCRIPTION
This PR addresses issue #9 

The value of the project selector is now being stored in a state in order to control the disabled state of the save button.
The dashboard tests have been updated to select a project before trying to save the form.
A new test has been created to validate if the button is really disabled when no project is selected.