### PR TITLE
Add "Administrative" item to admin users on navbar

### DIFF
--- a/app/views/refills/_navigation.html.erb
+++ b/app/views/refills/_navigation.html.erb
@@ -21,6 +21,12 @@
           <%= link_to repositories_path do %>
             <%= t('.open_source') %>
           <%- end %>
+
+          <% if current_user.is_admin? %>
+            <%= link_to "/admin" do %>
+              <%= t('.administrative') %>
+            <%- end %>
+          <%- end %>
         </div>
 
         <div class="navbar-nav ml-auto nav-link">

--- a/app/views/refills/_navigation.html.erb
+++ b/app/views/refills/_navigation.html.erb
@@ -23,7 +23,7 @@
           <%- end %>
 
           <% if current_user.is_admin? %>
-            <%= link_to "/admin" do %>
+            <%= link_to admin_root_path do %>
               <%= t('.administrative') %>
             <%- end %>
           <%- end %>

--- a/config/locales/pt-BR/pt-BR.yml
+++ b/config/locales/pt-BR/pt-BR.yml
@@ -52,6 +52,7 @@ pt-BR:
       logout: "Sair"
       dashboard: 'Dashboard'
       open_source: "Open Source"
+      administrative: 'Administrativo'
   repositories:
     index:
       open_source_repositories: "Projetos Open Source"

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -12,6 +12,7 @@ pt-BR:
       account: 'Conta'
       logout: 'Sair'
       dashboard: 'Dashboard'
+      administrative: 'Administrativo'
   punches:
     index:
       total: 'TOTAL'


### PR DESCRIPTION
Currently, to access the administrative dashboard, the user must type "/admin" at the end of the URL. This PR fixes this by adding an "Administrative" link on the header of the page.

If the current user is an admin:
![image](https://user-images.githubusercontent.com/50644753/134403638-da629a86-f256-4cb2-bebd-0c9512aaaf95.png)

Otherwise:
![image](https://user-images.githubusercontent.com/50644753/134403688-fbc79660-10cb-4930-8d78-6b1532c0d680.png)

Closes #25 