### PR TITLE
Use i18n in application_controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   # https://github.com/plataformatec/devise/issues/3461
   rescue_from ActionController::InvalidAuthenticityToken do |_exception|
     if devise_controller?
-      redirect_to root_path, alert: 'Already logged out'
+      redirect_to root_path, alert: I18n.t('devise.failure.already_logged_out')
     else
       raise
     end
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate_admin_user!
     unless !current_user.nil? && current_user.has_admin_access?
-      redirect_to root_path, alert: 'Acesso negado'
+      redirect_to root_path, alert: I18n.t('devise.failure.access_denied')
     end
   end
 

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -19,6 +19,8 @@ en:
       inactive_account: "Disabled account."
       last_attempt: "You have one more attempt before your account is locked."
       is_not_admin: 'You are not an admin'
+      already_logged_out: 'Already logged out'
+      access_denied: 'Access denied'
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/config/locales/pt-BR/devise.yml
+++ b/config/locales/pt-BR/devise.yml
@@ -19,6 +19,8 @@ pt-BR:
       inactive_account: "Conta desativada"
       last_attempt: "Você tem mais uma tentativa antes de sua conta ser bloqueada."
       is_not_admin: 'Você não é um admin.'
+      already_logged_out: 'Já desconectado'
+      access_denied: 'Acesso negado'
     mailer:
       confirmation_instructions:
         subject: 'Instruções de confirmação'


### PR DESCRIPTION
### Changes:
- Added the translation string in the i18n resources
- Replaced the hardcoded label with a call to the rails I18N service.

Closes #32 