### PR TITLE
Generate password when creating a user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'aasm', '~> 5.0', '>= 5.0.8'
 gem 'platform-api', github: 'heroku/platform-api'
 gem 'letsencrypt-rails-heroku', group: 'production'
 
+gem 'passgen'
+
 group :test do
   gem 'capybara'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,7 @@ GEM
     passenger (6.0.8)
       rack
       rake (>= 0.8.1)
+    passgen (1.2.0)
     pg (1.2.3)
     popper_js (1.16.0)
     pry (0.14.0)
@@ -566,6 +567,7 @@ DEPENDENCIES
   listen (~> 3.2)
   normalize-rails (~> 4.1.1)
   passenger (~> 6.0)
+  passgen
   pg (~> 1.2)
   platform-api!
   pry-rails

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -10,7 +10,7 @@ ActiveAdmin.register User do
   menu parent: User.model_name.human(count: 2), priority: 1
 
   permit_params :name, :email, :github, :company_id, :level, :contract_type, :reviewer_id, :hour_cost,
-                :password, :has_api_token, :active, :allow_overtime, :office_id, :occupation, :role, :started_at,
+                :has_api_token, :active, :allow_overtime, :office_id, :occupation, :role, :started_at,
                 :observation, :specialty, skill_ids: []
 
   scope :all
@@ -205,7 +205,6 @@ ActiveAdmin.register User do
       f.input :specialty, as: :select, collection: User.specialty.values.map { |specialty| [specialty.text.humanize, specialty] }
       f.input :level, as: :select, collection: User.level.values.map { |level| [level.text.titleize,level] }
       f.input :contract_type, as: :select, collection: User.contract_type.values.map { |contract_type| [contract_type.text.humanize, contract_type] }
-      f.input :password if f.object.new_record?
       f.input :has_api_token, as: :boolean, :input_html => { checked: f.object.token? }
       f.input :allow_overtime
       f.input :active
@@ -222,6 +221,12 @@ ActiveAdmin.register User do
           send_data spreadsheet.to_string_io, filename: 'users.xls'
         end
       end
+    end
+
+    def build_new_resource
+      resource = super
+      resource.assign_attributes(password: PasswordGeneratorService.call)
+      resource
     end
 
     def save_resource(object)

--- a/app/services/password_generator_service.rb
+++ b/app/services/password_generator_service.rb
@@ -1,0 +1,8 @@
+require 'passgen'
+
+class PasswordGeneratorService
+  def self.call()
+    min_length = Devise.password_length.first
+    Passgen::generate(length: min_length)
+  end
+end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -132,7 +132,6 @@ describe 'Users', type: :feature do
         find('#user_contract_type').find(:option, 'Estagiário').select_option
         find('#user_role').find(:option, 'Admin').select_option
         check('Ativo')
-        fill_in 'Password', with: 'password'
         fill_in 'Observação', with: 'Observation'
 
         click_button 'Criar Usuário'

--- a/spec/services/password_generator_service_spec.rb
+++ b/spec/services/password_generator_service_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe PasswordGeneratorService do
+  it 'create a random password with devise minimum password length' do
+    password = PasswordGeneratorService.call
+    expect(password.length).to be(Devise.password_length.first)
+  end
+end


### PR DESCRIPTION
Close #6 

The password field has been removed from the user creation form, it's now randomly generated with [passgen](https://github.com/cryptice/Passgen), respecting Devise's minimum password length.