### PR TITLE
Create punch attachment tests

### DIFF
--- a/spec/factories/punches.rb
+++ b/spec/factories/punches.rb
@@ -9,5 +9,8 @@ FactoryBot.define do
     trait :is_extra_hour do
       extra_hour { true }
     end
+    trait :with_attachment do
+      attachment {Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/attachment.txt"))}
+    end
   end
 end

--- a/spec/features/punches_list_spec.rb
+++ b/spec/features/punches_list_spec.rb
@@ -10,6 +10,9 @@ feature 'Punches list' do
   let!(:other_punch) {
     create(:punch, user_id: authed_user.id, company_id: authed_user.company_id)
   }
+  let!(:punch_with_attachment) {
+    create(:punch, :with_attachment , user_id: authed_user.id, company_id: authed_user.company_id)
+  }
 
   before do
     visit '/punches'
@@ -47,5 +50,14 @@ feature 'Punches list' do
     click_button 'Filtrar'
 
     expect(page).to have_css('tbody tr', count: 1)
+  end
+
+  it "Renders attachment link" do
+    expect(page).to have_link('', href: punch_with_attachment.attachment_url)  
+  end
+
+  scenario 'follow attachment link' do
+    find("a[href='#{punch_with_attachment.attachment_url}']").click
+    expect(page).to have_content('This is a punch attachment')
   end
 end

--- a/spec/fixtures/attachment.txt
+++ b/spec/fixtures/attachment.txt
@@ -1,0 +1,1 @@
+This is a punch attachment


### PR DESCRIPTION
The attachment link rendering and its click action weren't being tested.
To test this:
1. Created a with_attachment trait in the punch factory.
2. Created attachment fixture.
3. Instantiated a punch with attachment before tests.
4. Tested if punch.attachment_url was rended on the page.
5. Tested if attachment content was shown after click.