### PR TITLE
Fix contribuitions by office by month test

### DIFF
--- a/app/queries/contributions_by_office_query.rb
+++ b/app/queries/contributions_by_office_query.rb
@@ -24,8 +24,8 @@ class ContributionsByOfficeQuery
     self
   end
 
-  def per_month(month)
-    date = Date.today.change(day: 1, month: month)
+  def per_month(past_month)
+    date = Date.today.change(day: 1, month: past_month.month, year: past_month.year)
 
     @relation = @relation.where("contributions.created_at >= :start_date AND contributions.created_at <= :end_date",
                                  start_date: date.beginning_of_month, end_date: date.end_of_month)

--- a/spec/queries/contributions_by_office_query_spec.rb
+++ b/spec/queries/contributions_by_office_query_spec.rb
@@ -82,11 +82,16 @@ RSpec.describe ContributionsByOfficeQuery do
       user = create(:user, company: company, office: offices.first)
 
       create_list(:contribution, 3, { user: user, company: company })
-      create_list(:contribution, 3, { user: user, company: company, created_at: 1.month.ago })
+      create_list(:contribution, 4, { user: user, company: company, created_at: 1.month.ago })
+      create_list(:contribution, 5, { user: user, company: company, created_at: 13.month.ago })
     end
 
-    it 'return the right number of contributions', :skip do
-      expect(subject.per_month(1.month.ago.month).to_relation.first.number_of_contributions).to eq(3)
+    it 'return the right number of contributions' do
+      expect(subject.per_month(1.month.ago).to_relation.first.number_of_contributions).to eq(4)
+    end
+
+    it 'return the right number of contributions from more than 1 year ago' do
+      expect(subject.per_month(13.month.ago).to_relation.first.number_of_contributions).to eq(5)
     end
   end
 


### PR DESCRIPTION
This test only broke during january, worked fine in other months.
When past month went over to another year, the query failed.
Changed per_month argument to receive a date, not a month.
Maybe this will break something, but all tests passed.