### PR TITLE
Improves tests for ContributionsByUserQuery

### DIFF
--- a/spec/queries/contributions_by_user_query_spec.rb
+++ b/spec/queries/contributions_by_user_query_spec.rb
@@ -8,22 +8,24 @@ RSpec.describe ContributionsByUserQuery do
   let(:user)    { create(:user, company: company, office: offices.first) }
 
   context '#to_hash' do
+    subject(:to_hash) { described_class.new.to_hash }
+
     before do
       create_list(:contribution, 6, { user: user, company: company })
     end
 
-    subject(:to_hash) { described_class.new.to_hash }
-
-    it 'return the user name' do
+    it 'returns the user name' do
       expect(subject.keys.first).to eq(user.id)
     end
 
-    it 'return the right number of contributions' do
+    it 'returns the right number of contributions' do
       expect(subject[user.id]).to eq(6)
     end
   end
 
   context '#by_company' do
+    subject(:by_company) { described_class.new.by_company(company) }
+
     before do
       company_two = create(:company)
       other_office = create(:office, { company: company_two })
@@ -33,9 +35,7 @@ RSpec.describe ContributionsByUserQuery do
       create_list(:contribution, 5, { user: @other_company_user, company: company_two })
     end
 
-    subject(:by_company) { described_class.new.by_company(company) }
-
-    it 'return contributions of users by company' do
+    it 'returns contributions of users by company' do
       expect(subject.to_hash.keys).to include(user.id)
     end
 
@@ -45,28 +45,29 @@ RSpec.describe ContributionsByUserQuery do
   end
 
   context '#per_month' do
+    subject(:per_month) { described_class.new.per_month(1) }
+
     before do
       travel_to Date.new(2022, 1, 15)
       create_list(:contribution, 3, { user: user, company: company })
       create_list(:contribution, 3,
                   { user: user, company: company, created_at: Date.today.last_month })
     end
-    subject(:per_month) { described_class.new.per_month(1) }
 
-    it 'returns the number of contributions from the respective month' do
+    it 'returns the right number of contributions' do
       expect(subject.to_hash.first.last).to eq(3)
     end
   end
 
   context '#approved' do
+    subject(:approved) { described_class.new.approved }
+
     before do
       create_list(:contribution, 3, { user: user, company: company })
       create_list(:contribution, 3, { user: user, company: company, state: :approved })
     end
 
-    subject(:approved) { described_class.new.approved }
-
-    it 'returns the right number of approved contributions' do
+    it 'returns the right number of contributions' do
       expect(subject.to_hash.first.last).to eq(3)
     end
   end

--- a/spec/queries/contributions_by_user_query_spec.rb
+++ b/spec/queries/contributions_by_user_query_spec.rb
@@ -45,12 +45,15 @@ RSpec.describe ContributionsByUserQuery do
   end
 
   context '#per_month' do
+    let(:today) { Date.today }
+    let(:last_month) { today.month - 1 }
+
     before do
       create_list(:contribution, 3, { user: user, company: company })
-      create_list(:contribution, 1, { user: user, company: company, created_at: 1.month.ago })
+      create_list(:contribution, 3,
+                  { user: user, company: company, created_at: Date.new(today.year, last_month, 13) })
     end
-
-    subject(:per_month) { described_class.new.per_month(Time.now.month) }
+    subject(:per_month) { described_class.new.per_month(today.month) }
 
     it 'returns the number of contributions from the respective month' do
       expect(subject.to_hash.first.last).to eq(3)

--- a/spec/queries/contributions_by_user_query_spec.rb
+++ b/spec/queries/contributions_by_user_query_spec.rb
@@ -45,15 +45,13 @@ RSpec.describe ContributionsByUserQuery do
   end
 
   context '#per_month' do
-    let(:today) { Date.today }
-    let(:last_month) { today.month - 1 }
-
     before do
+      travel_to Date.new(2022, 1, 15)
       create_list(:contribution, 3, { user: user, company: company })
       create_list(:contribution, 3,
-                  { user: user, company: company, created_at: Date.new(today.year, last_month, 13) })
+                  { user: user, company: company, created_at: Date.today.last_month })
     end
-    subject(:per_month) { described_class.new.per_month(today.month) }
+    subject(:per_month) { described_class.new.per_month(1) }
 
     it 'returns the number of contributions from the respective month' do
       expect(subject.to_hash.first.last).to eq(3)


### PR DESCRIPTION
* The old test fails when running in March, returning 6 contributions instead of the expected 3
* Changes descriptions to third-person singular
* Moves subject to the first position after `context` blocks