### PR TITLE
Display only contributions of active engineers in contributions index

### DIFF
--- a/app/admin/contributions.rb
+++ b/app/admin/contributions.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register Contribution do
     redirect_back fallback_location: collection_path, notice: I18n.t('contributions_sent_to_newsletter')
   end
 
-  scope :all, default: true
+  scope :all, :active_engineers, default: true
 
   scope I18n.t(:this_week), :this_week, group: :time
   scope I18n.t(:last_week), :last_week, group: :time

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -26,4 +26,5 @@ class Contribution < ApplicationRecord
 
   scope :this_week, -> { where("contributions.created_at >= :start_date", { :start_date => Date.today.beginning_of_week }) }
   scope :last_week, -> { where("contributions.created_at >= :start_date AND contributions.created_at <= :end_date", { :start_date => 1.week.ago.beginning_of_week, :end_date => 1.week.ago.end_of_week }) }
+  scope :active_engineers, -> { joins(:user).merge(User.engineer.active) }
 end

--- a/spec/features/admin/contributions_spec.rb
+++ b/spec/features/admin/contributions_spec.rb
@@ -3,9 +3,12 @@ require 'sidekiq/testing'
 
 require 'rails_helper'
 
+RSpec::Matchers.define_negated_matcher :not_have_text, :have_text
+
 describe 'Contribution', type: :feature do
   let(:admin_user) { create(:user, :super_admin, occupation: :administrative) }
   let!(:contribution) { create(:contribution) }
+  let!(:inactive_user_contribution) { create(:contribution, :approved, user: create(:user, :inactive_user)) }
 
   before do
     sign_in(admin_user)
@@ -19,6 +22,24 @@ describe 'Contribution', type: :feature do
                         have_text('Empresa') &
                         have_text('Link') &
                         have_text('Estado')
+      end
+    end
+
+    it 'have contribution table with correct information of active user' do
+      within 'table' do
+        expect(page).to have_text(contribution.user) &
+                        have_text(contribution.company) &
+                        have_text(contribution.link) &
+                        have_text(Contribution.human_attribute_name("state/#{contribution.state}"))
+      end
+    end
+
+    it 'have contribution table without information of inactive user' do
+      within 'table' do
+        expect(page).to not_have_text(inactive_user_contribution.user) &
+                        not_have_text(inactive_user_contribution.company) &
+                        not_have_text(inactive_user_contribution.link) &
+                        not_have_text(Contribution.human_attribute_name("state/#{inactive_user_contribution.state}"))
       end
     end
   end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Contribution, type: :model do
   describe 'scopes' do
     let!(:today_contribution) { create :contribution }
     let!(:last_week_contribution) { create :contribution, created_at: 1.week.ago }
+    let!(:inactive_user_contribution) { create :contribution, user: create(:user, :inactive) }
 
     it 'is in this week' do
       expect(described_class.this_week.first).to eq(today_contribution)
@@ -64,6 +65,11 @@ RSpec.describe Contribution, type: :model do
 
     it 'is in last week' do
       expect(described_class.last_week.first).to eq(last_week_contribution)
+    end
+
+    it 'has active engineer' do
+      expect(described_class.active_engineers).to include(today_contribution, last_week_contribution)
+      expect(described_class.active_engineers).not_to include inactive_user_contribution
     end
   end
 end

--- a/spec/queries/contributions_by_office_query_spec.rb
+++ b/spec/queries/contributions_by_office_query_spec.rb
@@ -78,7 +78,13 @@ RSpec.describe ContributionsByOfficeQuery do
   end
 
   context 'per_month' do
+    around do |example|
+      travel_to(DateTime.new(2022,01, 01), &example)
+    end
+
     before do
+      travel_to '2022-01-01'.to_date
+
       user = create(:user, company: company, office: offices.first)
 
       create_list(:contribution, 3, { user: user, company: company })


### PR DESCRIPTION
Closes #95 

I realized that contribution rows of inactive engineers were also displayed on the contributions index page, making them appear in the exports. 

I'm approaching this situation by filtering them out on the index page.