### PR TITLE
Create all punches endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'kaminari'
 gem 'spreadsheet'
 gem 'httparty'
 gem 'github_api', '~> 0.18.2'
+gem 'active_model_serializers', '~> 0.10.13'
+
 
 gem 'ransack', '~> 2.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,11 @@ GEM
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
     active_admin_flat_skin (0.1.2)
     active_admin_theme (1.1.4)
+    active_model_serializers (0.10.13)
+      actionpack (>= 4.1, < 7.1)
+      activemodel (>= 4.1, < 7.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     active_skin (0.0.13)
     activeadmin (2.9.0)
       arbre (~> 1.2, >= 1.2.1)
@@ -141,6 +146,8 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    case_transform (0.2)
+      activesupport
     certified (1.0.0)
     chartkick (4.1.3)
     childprocess (4.1.0)
@@ -247,6 +254,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     jquery_mask_rails (0.1.0)
+    jsonapi-renderer (0.2.2)
     jwt (2.3.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -515,6 +523,7 @@ DEPENDENCIES
   aasm (~> 5.0, >= 5.0.8)
   active_admin_flat_skin
   active_admin_theme
+  active_model_serializers (~> 0.10.13)
   active_skin
   activeadmin (~> 2.9.0)
   autoprefixer-rails (~> 10.4.2.0)

--- a/app/controllers/api/v1/punches_controller.rb
+++ b/app/controllers/api/v1/punches_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class PunchesController < ApiController
+      def index
+        render json: scoped_punches, status: :ok, each_serializer: PunchSerializer
+      end
+
+      private
+
+      def scoped_punches
+        current_user.punches
+      end
+    end
+  end
+end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,0 +1,4 @@
+class ProjectSerializer < ActiveModel::Serializer
+  belongs_to :punch
+  attributes :name
+end

--- a/app/serializers/punch_serializer.rb
+++ b/app/serializers/punch_serializer.rb
@@ -1,0 +1,4 @@
+class PunchSerializer < ActiveModel::Serializer
+  attributes :created_at, :from, :to, :delta_as_hour, :extra_hour
+  has_one :project
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
       get "users" => "companies#users"
       get "offices" => "companies#offices"
       get "holidays" => "holidays#holidays_dashboard"
+      get "punches" => "punches#index"
     end
   end
 

--- a/spec/controllers/api/v1/punches_controller_spec.rb
+++ b/spec/controllers/api/v1/punches_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require  "#{Rails.root}/spec/support/controller_helpers.rb"
+
+describe Api::V1::PunchesController, :type => :controller do
+  let(:user) { create(:user, :with_token) }
+  subject { get :index }
+
+  describe 'GET api/v1/punches' do
+    before { create(:punch, user_id: user.id) }
+
+    context 'when user is logged in' do
+      let(:headers) { { token: user.token } }
+
+      before { request.headers.merge(headers) }
+
+      include_examples 'an authenticated resource action'
+
+      it 'returns all punches for the current user' do
+        expect(JSON.parse(subject.body)).to all(include('created_at', 'delta_as_hour', 'extra_hour', 'from', 'project', 'to'))
+      end
+    end
+
+    context 'when user is not logged in' do
+      include_examples 'an unauthenticated resource action'
+    end
+  end
+end

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -1,0 +1,24 @@
+# To include this example you must provide an authentication token into the "headers"
+# attributes.
+#
+# Example:
+#   let(:headers) { { token: user.token } }
+RSpec.shared_examples 'an authenticated resource action' do
+  it { is_expected.to have_http_status(:ok) }
+
+  it 'returns content type json' do
+    expect(subject.content_type).to eq 'application/json; charset=utf-8'
+  end
+end
+
+RSpec.shared_examples 'an unauthenticated resource action' do
+  it { is_expected.to have_http_status(:unauthorized) }
+
+  it 'returns content type json' do
+    expect(subject.content_type).to eq 'application/json; charset=utf-8'
+  end
+
+  it 'returns a missing token message' do
+    expect(JSON.parse(subject.body)).to eq('message' => 'Missing Token')
+  end
+end


### PR DESCRIPTION
Issue: #104 

This PR adds an endpoint to list all punches registered to the authenticated user.

This is how the response is working:

```json
[
    {
        "created_at": "2022-04-26T09:53:51.248-03:00",
        "from": "2021-10-26T08:00:00.000-03:00",
        "to": "2021-10-26T12:00:00.000-03:00",
        "delta_as_hour": "04:00",
        "extra_hour": false,
        "project": {
            "name": "Rito Gomes"
        }
    },
    {
        "created_at": "2022-04-26T09:53:51.252-03:00",
        "from": "2021-10-26T13:00:00.000-03:00",
        "to": "2021-10-26T16:00:00.000-03:00",
        "delta_as_hour": "03:00",
        "extra_hour": false,
        "project": {
            "name": "Rito Gomes"
        }
    }
```