### PR TITLE
Update repository select to show repositories ordered by total of contributions

### DIFF
--- a/app/admin/contributions.rb
+++ b/app/admin/contributions.rb
@@ -81,7 +81,8 @@ ActiveAdmin.register Contribution do
       else
         f.input :company_id, as: :hidden, input_html: { value: current_user.company_id }
       end
-      input :repository
+
+      input :repository, collection: RepositoriesOrderedByContributionsQuery.new.call
       input :link
     end
     f.actions

--- a/app/queries/repositories_ordered_by_contributions_query.rb
+++ b/app/queries/repositories_ordered_by_contributions_query.rb
@@ -1,0 +1,15 @@
+class RepositoriesOrderedByContributionsQuery
+  def call
+    repositories_query = <<-SQL
+      SELECT r.id, r.link FROM repositories r
+        ORDER BY (
+          SELECT count(*)
+          FROM contributions c
+          WHERE r.id = c.repository_id
+        ) DESC
+    SQL
+
+    repositories_rank = ActiveRecord::Base.connection.execute(repositories_query)
+    repositories_rank.map { |repository| [repository['link'], repository['id']] }
+  end
+end

--- a/spec/queries/repositories_ordered_by_contributions_query_spec.rb
+++ b/spec/queries/repositories_ordered_by_contributions_query_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RepositoriesOrderedByContributionsQuery do
+  describe '.call' do
+    subject(:call) { described_class.new.call }
+
+    let!(:repo1) { create(:repository) }
+    let!(:repo2) { create(:repository) }
+    let!(:repo3) { create(:repository) }
+
+    context 'when repositories have different number of contributions each' do
+      let!(:contribution1) { create(:contribution, repository: repo2) }
+      let!(:contribution2) { create(:contribution, repository: repo2) }
+      let!(:contribution3) { create(:contribution, repository: repo3) }
+
+      it 'returns repositories list ordered by contributions count' do
+        expect(call).to eq [[repo2.link, repo2.id], [repo3.link, repo3.id], [repo1.link, repo1.id]]
+      end
+    end
+
+    context 'when all repositories have the same number of contributions' do
+      let!(:contribution1) { create(:contribution, repository: repo1) }
+      let!(:contribution3) { create(:contribution, repository: repo3) }
+      let!(:contribution2) { create(:contribution, repository: repo2) }
+
+      it 'returns repositories list ordered by id' do
+        expect(call).to eq [[repo1.link, repo1.id], [repo2.link, repo2.id], [repo3.link, repo3.id]]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolve: [#114 ](https://github.com/Codeminer42/Punchclock/issues/114)

- [x] When creating a new contribution, the repositories should be ordered by their number of contributions.

![Screenshot_20220505_105545 (1)](https://user-images.githubusercontent.com/30778707/166942855-8e7d06aa-5042-4b8e-ac95-fd402400e93a.png)
