### PR TITLE
Show one Punch endpoint to authenticated user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       slop (~> 3.0)
     public_suffix (4.0.6)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-proxy (0.7.2)
       rack
     rack-test (1.1.0)

--- a/app/controllers/api/v1/punches_controller.rb
+++ b/app/controllers/api/v1/punches_controller.rb
@@ -5,10 +5,18 @@ module Api
         render json: scoped_punches, status: :ok, each_serializer: PunchSerializer
       end
 
+      def show
+        render json: scoped_punch, status: :found, each_serializer: PunchSerializer
+      end
+
       private
 
       def scoped_punches
         current_user.punches
+      end
+
+      def scoped_punch
+        scoped_punches.find(params[:id])
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
       get "offices" => "companies#offices"
       get "holidays" => "holidays#holidays_dashboard"
       get "punches" => "punches#index"
+      get "punches/:id" => "punches#show", as: :punch
     end
   end
 

--- a/spec/controllers/api/v1/punches_controller_spec.rb
+++ b/spec/controllers/api/v1/punches_controller_spec.rb
@@ -3,9 +3,9 @@ require  "#{Rails.root}/spec/support/controller_helpers.rb"
 
 describe Api::V1::PunchesController, :type => :controller do
   let(:user) { create(:user, :with_token) }
-  subject { get :index }
 
   describe 'GET api/v1/punches' do
+    subject { get :index }
     before { create(:punch, user_id: user.id) }
 
     context 'when user is logged in' do
@@ -15,8 +15,33 @@ describe Api::V1::PunchesController, :type => :controller do
 
       include_examples 'an authenticated resource action'
 
+      it { is_expected.to have_http_status(:ok) }
+
       it 'returns all punches for the current user' do
         expect(JSON.parse(subject.body)).to all(include('created_at', 'delta_as_hour', 'extra_hour', 'from', 'project', 'to'))
+      end
+    end
+
+    context 'when user is not logged in' do
+      include_examples 'an unauthenticated resource action'
+    end
+  end
+
+  describe 'GET api/v1/punches/:id' do
+    subject { get :show, params: { id: punch.id } }
+    let(:punch) { create(:punch, user_id: user.id) }
+
+    context 'when user is logged in' do
+      let(:headers) { { token: user.token } }
+
+      before { request.headers.merge(headers) }
+
+      include_examples 'an authenticated resource action'
+
+      it { is_expected.to have_http_status(:found) }
+
+      it 'returns selected punch for the current user' do
+        expect(JSON.parse(subject.body)).to include('created_at', 'delta_as_hour', 'extra_hour', 'from', 'project', 'to')
       end
     end
 

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -4,8 +4,6 @@
 # Example:
 #   let(:headers) { { token: user.token } }
 RSpec.shared_examples 'an authenticated resource action' do
-  it { is_expected.to have_http_status(:ok) }
-
   it 'returns content type json' do
     expect(subject.content_type).to eq 'application/json; charset=utf-8'
   end


### PR DESCRIPTION
Issue: #105 
This PR adds an endpoint to list all punches registered to the authenticated user.

This is how the response is working:
```json
{
    "created_at": "2022-04-26T09:53:22.722-03:00",
    "from": "2021-10-26T13:00:00.000-03:00",
    "to": "2021-10-26T16:00:00.000-03:00",
    "delta_as_hour": "03:00",
    "extra_hour": false,
    "project": {
        "name": "Punchclock"
    }
}

```