### PR TITLE
Update allocations page scopes

### DIFF
--- a/app/admin/allocations.rb
+++ b/app/admin/allocations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Allocation do
+  config.sort_order = 'end_at_asc'
   permit_params :user_id, :project_id, :start_at, :end_at, :company_id
 
   config.batch_actions = false
@@ -9,9 +10,9 @@ ActiveAdmin.register Allocation do
 
   scope :ongoing, default: true
   scope :finished
-  scope :all do |relation|
-    AllocationsAndUnalocatedUsersQuery.new(relation, current_user.company)
-                                      .call
+  scope :all
+  scope :spreadsheet do |relation|
+    AllocationsAndUnalocatedUsersQuery.new(relation, current_user.company).call
   end
 
   filter :user, collection: proc {

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -12,8 +12,15 @@ class Allocation < ApplicationRecord
 
   delegate :office_name, to: :user
 
-  scope :ongoing, -> { where("end_at > :today OR end_at is NULL", today: Date.current).order(start_at: :desc) }
-  scope :finished, -> { where("end_at < :today", today: Date.current).order(end_at: :desc) }
+  scope :ongoing, -> { 
+    where("end_at > :today OR end_at is NULL", today: Date.current)
+    .where(user_id: User.active)
+    .order(start_at: :desc) 
+  }
+  scope :finished, -> {
+    where("end_at < :today", today: Date.current)
+    .where(user_id: User.active)
+    .order(end_at: :desc) }
   scope :in_period, -> (start_at, end_at) do
     where(
       "daterange(start_at, end_at, '[]') && daterange(:start_at, :end_at, '[]')",

--- a/config/locales/pt-BR/active_admin.yml
+++ b/config/locales/pt-BR/active_admin.yml
@@ -24,7 +24,8 @@ pt-BR:
       active: 'Ativo'
       inactive: 'Inativo'
       finished: 'Finalizadas'
-      ongoing: 'Em andamento'
+      ongoing: 'Em andamento'      
+      spreadsheet: 'Planilha'
     resources:
       user:
         scopes:

--- a/config/locales/pt-BR/active_admin.yml
+++ b/config/locales/pt-BR/active_admin.yml
@@ -20,9 +20,11 @@ pt-BR:
         approve: 'Aprovar'
         send_to_newsletter: 'Enviar para Newsletter'
     scopes:
-      all: Todos
+      all: 'Todos'
       active: 'Ativo'
       inactive: 'Inativo'
+      finished: 'Finalizadas'
+      ongoing: 'Em andamento'
     resources:
       user:
         scopes:

--- a/spec/features/admin/allocations_spec.rb
+++ b/spec/features/admin/allocations_spec.rb
@@ -28,6 +28,13 @@ describe 'Admin Allocation', type: :feature do
                         have_text('Dias Restantes')
       end
     end
+
+    it 'must find scopes "Em andamento", "Finalizadas", "Todos", and "Planilha"' do
+        expect(page).to have_text('Em andamento (1)') &
+                        have_text('Finalizadas (0)') &
+                        have_text('Todos (1)') &
+                        have_text('Planilha (1)')
+    end
   end
 
   describe 'Filters' do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -114,6 +114,38 @@ RSpec.describe Allocation, type: :model do
     end
   end
 
+  describe 'scopes' do
+    let!(:user1) { create(:user, active: false) }
+    let!(:user2) { create(:user) }
+    let!(:allocation1) { create(:allocation,
+                                  start_at: 2.week.ago,
+                                  end_at: 1.week.after,
+                                  user: user1)}
+    let!(:allocation2) { create(:allocation,
+                                  start_at: 2.week.ago,
+                                  end_at: 1.week.after,
+                                  user: user2)}
+    let!(:allocation3) { create(:allocation,
+                                  start_at: 2.month.ago,
+                                  end_at: 1.month.ago,
+                                  user: user1)}
+    let!(:allocation4) { create(:allocation,
+                                  start_at: 2.month.ago,
+                                  end_at: 1.month.ago,
+                                  user: user2)}
+
+    let(:ongoing_allocations) { described_class.ongoing.map { |allocation| allocation } }
+    let(:finished_allocations) { described_class.finished.map { |allocation| allocation } }
+
+    it 'is ongoing' do                                    
+      expect(ongoing_allocations).to eq([allocation2])
+    end
+
+    it 'is finished' do                                    
+      expect(finished_allocations).to eq([allocation4])
+    end
+  end
+
   describe '#days_until_finish' do
     context 'when end_at is nil' do
       subject { build_stubbed(:allocation, end_at: nil) }


### PR DESCRIPTION
Resolves: #132

- [x] Update allocation ongoing and finished scopes to list only active users;
- [x] Add translations to allocation page scopes;
- [x] Create scope "Planilha" in allocation page;
- [x] Set the table to be sorted by "end_at". 
![Screenshot_20220721_161741](https://user-images.githubusercontent.com/30778707/180298533-fe997382-482b-4a25-9865-c5672588b924.png)
