### PR TITLE
Add ongoing property to Allocation model

### DIFF
--- a/app/admin/allocations.rb
+++ b/app/admin/allocations.rb
@@ -74,9 +74,10 @@ ActiveAdmin.register Allocation do
         end
       end
       div link_to I18n.t('download_as_csv'),
-                  admin_punches_path(q: { project_id_eq: allocation.project.id,
-                                          user_id_eq: allocation.user.id,
-                                          from_greater_than: 60.days.ago.to_date }, format: :csv)
+                    admin_punches_path(q: { project_id_eq: allocation.project.id,
+                                            user_id_eq: allocation.user.id,
+                                            from_greater_than: 60.days.ago.to_date
+                                          }, format: :csv)
     end
   end
 
@@ -93,10 +94,7 @@ ActiveAdmin.register Allocation do
                                       .select(:id, :name)
 
         input :user, as: :select, collection: company_users_not_allocated
-        input :project,
-              collection: (current_user.company.projects.active.to_a | [@resource.project])
-                .reject(&:blank?)
-                .sort_by(&:name)
+        input :project, collection: (current_user.company.projects.active.to_a | [@resource.project]).reject(&:blank?).sort_by(&:name)
         input :company_id, as: :hidden, input_html: { value: current_user.company_id }
       end
 

--- a/app/admin/allocations.rb
+++ b/app/admin/allocations.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Allocation do
   config.sort_order = ''
-  permit_params :user_id, :project_id, :start_at, :end_at, :company_id
+  permit_params :user_id, :project_id, :start_at, :end_at, :company_id, :ongoing
 
   config.batch_actions = false
 
@@ -46,6 +46,7 @@ ActiveAdmin.register Allocation do
     column :start_at, sortable: false
     column :end_at, sortable: false
     column :days_left, &:days_until_finish
+    column :ongoing
     actions
   end
 
@@ -56,6 +57,7 @@ ActiveAdmin.register Allocation do
       row :start_at
       row :end_at
       row :days_left, &:days_until_finish
+      row :ongoing
     end
 
     panel t('allocated_user_punches', scope: 'active_admin') do
@@ -72,10 +74,9 @@ ActiveAdmin.register Allocation do
         end
       end
       div link_to I18n.t('download_as_csv'),
-                    admin_punches_path(q: { project_id_eq: allocation.project.id,
-                                            user_id_eq: allocation.user.id,
-                                            from_greater_than: 60.days.ago.to_date
-                                          }, format: :csv)
+                  admin_punches_path(q: { project_id_eq: allocation.project.id,
+                                          user_id_eq: allocation.user.id,
+                                          from_greater_than: 60.days.ago.to_date }, format: :csv)
     end
   end
 
@@ -92,12 +93,16 @@ ActiveAdmin.register Allocation do
                                       .select(:id, :name)
 
         input :user, as: :select, collection: company_users_not_allocated
-        input :project, collection: (current_user.company.projects.active.to_a | [@resource.project]).reject(&:blank?).sort_by(&:name)
+        input :project,
+              collection: (current_user.company.projects.active.to_a | [@resource.project])
+                .reject(&:blank?)
+                .sort_by(&:name)
         input :company_id, as: :hidden, input_html: { value: current_user.company_id }
       end
 
       input :start_at, as: :date_picker, input_html: { value: f.object.start_at }
       input :end_at, as: :date_picker, input_html: { value: f.object.end_at }
+      input :ongoing
     end
     actions
   end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -127,6 +127,7 @@ ActiveAdmin.register User do
               end
               column :start_at
               column :end_at
+              column :ongoing
               column '' do |allocation|
                 link_to 'Access Allocation', admin_allocation_path(allocation)
               end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -10,28 +10,27 @@ class Allocation < ApplicationRecord
   validate :end_date
   validate :unique_period, unless: :end_before_start?
   validates :ongoing, uniqueness: { scope: :user, message: :uniqueness },
-                      if: :ongoing
+                      if: :ongoing?
 
   delegate :office_name, to: :user
 
-  scope :ongoing, lambda {
+  scope :ongoing, -> { 
     where("end_at > :today OR end_at is NULL", today: Date.current)
-      .where(user_id: User.active)
-      .order(start_at: :desc)
+    .where(user_id: User.active)
+    .order(start_at: :desc) 
   }
-  scope :finished, lambda {
-                     where("end_at < :today", today: Date.current)
-                       .where(user_id: User.active)
-                       .order(end_at: :desc)
-                   }
-  scope :in_period, lambda { |start_at, end_at|
+  scope :finished, -> {
+    where("end_at < :today", today: Date.current)
+    .where(user_id: User.active)
+    .order(end_at: :desc) }
+  scope :in_period, -> (start_at, end_at) do
     where(
       "daterange(start_at, end_at, '[]') && daterange(:start_at, :end_at, '[]')",
       start_at: start_at,
       end_at: end_at
     )
-  }
-
+  end
+  
   def days_until_finish
     return unless end_at
 
@@ -48,7 +47,7 @@ class Allocation < ApplicationRecord
   end
 
   private
-
+  
   def end_before_start?
     end_at.present? && end_at < start_at
   end
@@ -59,7 +58,7 @@ class Allocation < ApplicationRecord
 
   def unique_period
     return unless Allocation.in_period(start_at, end_at).where.not(id: id).exists?(user_id: user_id)
-
+  
     errors.add(:start_at, :overlapped_period)
   end
 end

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -17,3 +17,7 @@ en:
             base:
               overlap: The chosen date overlaps with ones already registered
               invalid_periods: The periods reported do not follow a valid chronological order
+        allocation:
+          attributes:
+            ongoing:
+              uniqueness: 'The user already has an ongoing allocation' 

--- a/config/locales/pt-BR/models.yml
+++ b/config/locales/pt-BR/models.yml
@@ -235,6 +235,7 @@ pt-BR:
         client: "Cliente"
         project_name: "Nome do Projeto"
         access: "Acessar"
+        ongoing: "Em progresso"
         created_at: "Criado em"
         updated_at: "Atualizado em"
       evaluation:

--- a/config/locales/pt-BR/models.yml
+++ b/config/locales/pt-BR/models.yml
@@ -44,6 +44,8 @@ pt-BR:
             end_at:
               cant_be_lesser: "A data de término deve ser maior que a data de início"
               invalid_date: "Data Inválida"
+            ongoing: 
+              uniqueness: 'O usuário já possui uma alocação em progresso' 
     models:
       admin_user:
         one: "Administrador"

--- a/db/migrate/20220817133652_add_ongoing_to_allocation.rb
+++ b/db/migrate/20220817133652_add_ongoing_to_allocation.rb
@@ -1,0 +1,5 @@
+class AddOngoingToAllocation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :allocations, :ongoing, :boolean, { default: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_17_142319) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_17_133652) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_142319) do
     t.bigint "company_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "ongoing", default: false
     t.index ["company_id"], name: "index_allocations_on_company_id"
     t.index ["project_id"], name: "index_allocations_on_project_id"
     t.index ["user_id"], name: "index_allocations_on_user_id"

--- a/lib/tasks/allocations.rake
+++ b/lib/tasks/allocations.rake
@@ -1,0 +1,10 @@
+namespace :allocations do
+  desc 'Update users current allocation ongoing column'
+  task update_users_current_allocation: :environment do
+    ActiveRecord::Base.transaction do
+      User.includes(:allocations).joins(:allocations).merge(Allocation.ongoing).each do |user|
+        user.allocations.last.update(ongoing: true)
+      end
+    end
+  end
+end

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     start_at { Date.today }
     end_at   { nil }
     company { user.company }
+    ongoing { false }
 
     trait :with_end_at do
       end_at { Faker::Date.between(from: Date.tomorrow, to: 4.days.after) }

--- a/spec/features/admin/allocations_spec.rb
+++ b/spec/features/admin/allocations_spec.rb
@@ -130,7 +130,8 @@ describe 'Admin Allocation', type: :feature do
           expect(page).to have_text('Usuário')  &
                           have_text('Projeto') &
                           have_text('Início') &
-                          have_text('Término')
+                          have_text('Término') &
+                          have_text('Em progresso')
         end
       end
 
@@ -172,7 +173,8 @@ describe 'Admin Allocation', type: :feature do
           expect(page).to have_text('Usuário') &
                           have_text('Projeto') &
                           have_text('Início') &
-                          have_text('Término')
+                          have_text('Término') &
+                          have_text('Em progresso')
         end
       end
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -14,35 +14,35 @@ RSpec.describe Allocation, type: :model do
 
   describe 'validate' do
     let(:user) { create(:user) }
-    let(:user_2) { create(:user) }
+    let(:user_2) { create(:user) } 
 
     context 'end_at' do
       it 'should not be before start_at' do
-        allocation = build(:allocation, user: user, start_at: 4.days.after, end_at: 2.days.after)
+        allocation = build(:allocation, user: user, start_at: 4.days.after, end_at: 2.days.after )
         allocation.validate
         expect(allocation.errors[:end_at]).to eq(['A data de término deve ser maior que a data de início'])
       end
     end
 
-    context 'selected dates' do
+    context 'selected dates' do  
       before do
-        create(:allocation, user: user, end_at: 1.week.after)
+        create(:allocation, user: user, end_at: 1.week.after)  
       end
-
+      
       it 'overlaps an existing period to same user' do
-        allocation = build(:allocation, user: user, start_at: 2.days.after, end_at: 2.week.after)
+        allocation = build(:allocation, user: user, start_at: 2.days.after, end_at: 2.week.after )
         allocation.validate
         expect(allocation.errors[:start_at]).to eq(['Já existe uma alocação desse usuário nesse período'])
       end
 
       it 'do not overlaps an existing period to another user' do
-        allocation = build(:allocation, user: user_2, start_at: 2.days.after, end_at: 2.week.after)
+        allocation = build(:allocation, user: user_2, start_at: 2.days.after, end_at: 2.week.after )
         allocation.validate
         expect(allocation.errors[:start_at]).not_to eq(['Já existe uma alocação desse usuário nesse período'])
       end
 
       it 'do not overlaps an existing period' do
-        allocation = build(:allocation, user: user, start_at: 8.days.after, end_at: 2.week.after)
+        allocation = build(:allocation, user: user, start_at: 8.days.after, end_at: 2.week.after )
         allocation.validate
         expect(allocation.errors[:start_at]).not_to eq(['Já existe uma alocação desse usuário nesse período'])
       end
@@ -95,8 +95,8 @@ RSpec.describe Allocation, type: :model do
 
         context 'update' do
           let(:allocation) { create(:allocation, end_at: 2.week.after, user: user) }
-
-          it 'should not be possible update an allocation to be endless' do
+          
+          it 'should not be possible update an allocation to be endless' do  
             allocation.end_at = nil
             allocation.validate
             expect(allocation.errors[:start_at]).to eq(['Já existe uma alocação desse usuário nesse período'])
@@ -108,14 +108,15 @@ RSpec.describe Allocation, type: :model do
             expect(allocation.errors[:start_at]).not_to eq(['Já existe uma alocação desse usuário nesse período'])
           end
         end
+
       end
+
     end
 
     context 'ongoing' do
       before do
         create(:allocation, user: user, start_at: 4.days.ago, end_at: 1.days.ago, ongoing: true)
       end
-
       it 'validates uniqueness of ongoing' do
         allocation = build(:allocation, user: user, ongoing: true)
         allocation.validate
@@ -127,39 +128,31 @@ RSpec.describe Allocation, type: :model do
   describe 'scopes' do
     let!(:user1) { create(:user, active: false) }
     let!(:user2) { create(:user) }
-    let!(:allocation1) do
-      create(:allocation,
-             start_at: 2.week.ago,
-             end_at: 1.week.after,
-             user: user1)
-    end
-    let!(:allocation2) do
-      create(:allocation,
-             start_at: 2.week.ago,
-             end_at: 1.week.after,
-             user: user2)
-    end
-    let!(:allocation3) do
-      create(:allocation,
-             start_at: 2.month.ago,
-             end_at: 1.month.ago,
-             user: user1)
-    end
-    let!(:allocation4) do
-      create(:allocation,
-             start_at: 2.month.ago,
-             end_at: 1.month.ago,
-             user: user2)
-    end
+    let!(:allocation1) { create(:allocation,
+                                  start_at: 2.week.ago,
+                                  end_at: 1.week.after,
+                                  user: user1)}
+    let!(:allocation2) { create(:allocation,
+                                  start_at: 2.week.ago,
+                                  end_at: 1.week.after,
+                                  user: user2)}
+    let!(:allocation3) { create(:allocation,
+                                  start_at: 2.month.ago,
+                                  end_at: 1.month.ago,
+                                  user: user1)}
+    let!(:allocation4) { create(:allocation,
+                                  start_at: 2.month.ago,
+                                  end_at: 1.month.ago,
+                                  user: user2)}
 
     let(:ongoing_allocations) { described_class.ongoing.map { |allocation| allocation } }
     let(:finished_allocations) { described_class.finished.map { |allocation| allocation } }
 
-    it 'is ongoing' do
+    it 'is ongoing' do                                    
       expect(ongoing_allocations).to eq([allocation2])
     end
 
-    it 'is finished' do
+    it 'is finished' do                                    
       expect(finished_allocations).to eq([allocation4])
     end
   end


### PR DESCRIPTION
#163

* Add `ongoing` property to Allocation model
* Update `allocations` active admin pages to present/manipulate ongoing info
* Update `user` active admin page to present ongoing info
* Create task to set current users allocation ongoing property to true

## Screen shots:

* image 1

![image](https://user-images.githubusercontent.com/79609888/185466820-346d2e86-6896-4603-bc2c-9f50e45acb1d.png)

* image 2

![image](https://user-images.githubusercontent.com/79609888/185466865-f31f6049-40bd-461f-89cb-0f202d9f97f8.png)

* image 3

![image](https://user-images.githubusercontent.com/79609888/185466945-d13698f6-525e-441e-a246-bd7593399f97.png)

* image 4

![image](https://user-images.githubusercontent.com/79609888/185467019-bda65c72-72d9-417b-bc0f-78206cfe6631.png)

* image 5

![image](https://user-images.githubusercontent.com/79609888/185467109-d6915c0a-6f65-4a39-9436-26d9e0db1d32.png)


