### PR TITLE
Changes allocation ongoing default form false to true

### DIFF
--- a/db/migrate/20220819180011_chage_allocation_ongoing_default.rb
+++ b/db/migrate/20220819180011_chage_allocation_ongoing_default.rb
@@ -1,0 +1,5 @@
+class ChageAllocationOngoingDefault < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :allocations, :ongoing, from: false, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_133652) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_180011) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,7 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_133652) do
     t.bigint "company_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.boolean "ongoing", default: false
+    t.boolean "ongoing", default: true
     t.index ["company_id"], name: "index_allocations_on_company_id"
     t.index ["project_id"], name: "index_allocations_on_project_id"
     t.index ["user_id"], name: "index_allocations_on_user_id"


### PR DESCRIPTION
As mentioned in #163, the default value was temporarily defined as `false` to keep compatibility with the existing allocation data. So this PR will change the default to `true`.