### PR TITLE
Update allocation chart highlight considering allocation `ongoing` property

### DIFF
--- a/app/admin/allocation_chart.rb
+++ b/app/admin/allocation_chart.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register_page 'Allocation Chart' do
 
   content title: I18n.t('allocation_chart') do
     panel I18n.t('allocation_chart') do
-      allocations = AllocationsAndUnalocatedUsersQuery.new(Allocation, current_user.company, with_ongoing: true).call
+      allocations = AllocationsAndUnalocatedUsersQuery.new(Allocation, current_user.company).call
       paginated_collection(allocations.page(params[:page]), download_links: false) do
         table_for collection do
           column(I18n.t('name'), :user)

--- a/app/admin/allocation_chart.rb
+++ b/app/admin/allocation_chart.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register_page 'Allocation Chart' do
 
   content title: I18n.t('allocation_chart') do
     panel I18n.t('allocation_chart') do
-      allocations = AllocationsAndUnalocatedUsersQuery.new(Allocation, current_user.company).call
+      allocations = AllocationsAndUnalocatedUsersQuery.new(Allocation, current_user.company, with_ongoing: true).call
       paginated_collection(allocations.page(params[:page]), download_links: false) do
         table_for collection do
           column(I18n.t('name'), :user)

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -89,12 +89,12 @@ body.logged_in .flash {
     }
 
     &--exp-in-30-days {
-      background-color: $red;
+      background-color: $flat-alizarin;
       color: $white;
     }
 
     &--expired {
-      background-color: $redDarker;
+      background-color: $red;
       color: $white;
     }
 

--- a/app/queries/allocations_and_unalocated_users_query.rb
+++ b/app/queries/allocations_and_unalocated_users_query.rb
@@ -1,26 +1,32 @@
 # frozen_string_literal: true
 
 class AllocationsAndUnalocatedUsersQuery
-  attr_reader :allocation, :company
+  attr_reader :allocation, :company, :with_ongoing
 
-  def initialize(allocation, company)
+  def initialize(allocation, company, with_ongoing: false)
     @allocation = allocation
     @company = company
+    @with_ongoing = with_ongoing
   end
 
   def call
-    allocation
+   query =  allocation
       .includes(:user)
       .select('allocations.*, users.id as user_id')
-      .joins(
-        'RIGHT OUTER JOIN users ON allocations.user_id = users.id AND
-        (allocations.end_at > NOW() OR allocations.end_at IS NULL)'
-      )
-      .where(where)
+      
+      joins_user(query).where(where)
       .order('end_at NULLS LAST, start_at NULLS LAST, users.name')
   end
 
   private
+
+  def joins_user(query)
+    query.joins(
+        "RIGHT OUTER JOIN users ON allocations.user_id = users.id AND #{
+        with_ongoing ? "allocations.ongoing = true" : "(allocations.end_at > NOW() OR allocations.end_at IS NULL)"
+        }"
+    )
+  end
 
   def where
     {

--- a/spec/features/admin/allocation_chart_spec.rb
+++ b/spec/features/admin/allocation_chart_spec.rb
@@ -12,7 +12,7 @@ describe 'Admin Allocation chart', type: :feature do
 
   describe 'Index' do
     let(:project) { create(:project, company: company) }
-    let!(:user) { create(:user, allocations: [build(:allocation, project: project, company: company)], company: company) }
+    let!(:user) { create(:user, allocations: [build(:allocation, project: project, company: company, ongoing: true)], company: company) }
 
     before { visit '/admin/allocation_chart' }
 

--- a/spec/queries/allocations_and_unalocated_users_query_spec.rb
+++ b/spec/queries/allocations_and_unalocated_users_query_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe AllocationsAndUnalocatedUsersQuery do
       let!(:roan) { create(:user, name: 'Roan Britt', company: company) }
       let!(:brian) { create(:user, name: 'Brian May', company: company) }
       let!(:leeroy) { create(:user, name: 'Leeroy Jenkins', company: company) }
+      let!(:satoshi) { create(:user, name: 'Satoshi Nakamoto', company: company) }
 
       let(:names) { call.map { |allocation| allocation.user.name } }
 
@@ -33,29 +34,47 @@ RSpec.describe AllocationsAndUnalocatedUsersQuery do
                start_at: 2.months.after,
                end_at: 3.months.after,
                user: roan,
-               company: company)
+               company: company,
+              ongoing: true)
+              
 
         create(:allocation,
-               start_at: 3.months.after,
+               start_at: 1.months.before,
                end_at: 4.months.after,
                user: brian,
-               company: company)
+               company: company,
+              ongoing: true)
 
         create(:allocation,
                start_at: 3.months.after,
                end_at: nil,
                user: alex,
-               company: company)
+               company: company,
+               ongoing: true)
 
         create(:allocation,
                start_at: 3.months.before,
                end_at: 2.months.before,
                user: leeroy,
                company: company)
+
+        create(:allocation,
+               start_at: 3.months.before,
+               end_at: 2.months.before,
+               user: satoshi,
+               company: company,
+               ongoing: true)
       end
 
       it 'returns users in order of allocations about to finish > without end > no allocation' do
-        expect(names).to eq ['Roan Britt', 'Brian May', 'Alex Doratov', 'John Doe', 'Leeroy Jenkins']
+        expect(names).to eq ['Roan Britt', 'Brian May', 'Alex Doratov', 'John Doe', 'Leeroy Jenkins', 'Satoshi Nakamoto']
+      end
+
+      context 'with ongoing' do 
+        subject(:call) { described_class.new(Allocation, company, with_ongoing: true).call }
+        it 'returns users with ongoing allocations in order of finished > allocations about to finish > without end > no allocation' do
+          expect(names).to eq ['Satoshi Nakamoto','Roan Britt', 'Brian May', 'Alex Doratov', 'John Doe', 'Leeroy Jenkins']
+        end
       end
     end
 

--- a/spec/queries/allocations_and_unalocated_users_query_spec.rb
+++ b/spec/queries/allocations_and_unalocated_users_query_spec.rb
@@ -35,15 +35,14 @@ RSpec.describe AllocationsAndUnalocatedUsersQuery do
                end_at: 3.months.after,
                user: roan,
                company: company,
-              ongoing: true)
-              
+               ongoing: true)
 
         create(:allocation,
                start_at: 1.months.before,
                end_at: 4.months.after,
                user: brian,
                company: company,
-              ongoing: true)
+               ongoing: true)
 
         create(:allocation,
                start_at: 3.months.after,
@@ -66,15 +65,8 @@ RSpec.describe AllocationsAndUnalocatedUsersQuery do
                ongoing: true)
       end
 
-      it 'returns users in order of allocations about to finish > without end > no allocation' do
-        expect(names).to eq ['Roan Britt', 'Brian May', 'Alex Doratov', 'John Doe', 'Leeroy Jenkins', 'Satoshi Nakamoto']
-      end
-
-      context 'with ongoing' do 
-        subject(:call) { described_class.new(Allocation, company, with_ongoing: true).call }
-        it 'returns users with ongoing allocations in order of finished > allocations about to finish > without end > no allocation' do
-          expect(names).to eq ['Satoshi Nakamoto','Roan Britt', 'Brian May', 'Alex Doratov', 'John Doe', 'Leeroy Jenkins']
-        end
+      it 'returns users with ongoing allocations in order of finished > allocations about to finish > without end > no allocation' do
+        expect(names).to eq ['Satoshi Nakamoto', 'Roan Britt', 'Brian May', 'Alex Doratov', 'John Doe', 'Leeroy Jenkins']
       end
     end
 


### PR DESCRIPTION
Now in allocation chart page, the column `Alocado até` shows expired allocation dates.

![image](https://user-images.githubusercontent.com/79609888/185707881-07292371-1b37-483f-9e3b-f910696221d5.png)

