### PR TITLE
Feature: Send email for canceled vacations

### DIFF
--- a/app/controllers/vacations_controller.rb
+++ b/app/controllers/vacations_controller.rb
@@ -31,6 +31,7 @@ class VacationsController < ApplicationController
 
     if vacation_to_cancel.pending?
       vacation_to_cancel.update!(status: :cancelled)
+      VacationMailer.notify_vacation_cancelled(vacation_to_cancel).deliver_later
       redirect_to vacations_path, notice: I18n.t(:notice, scope: "flash.vacation.cancel")
     else
       redirect_to vacations_path, alert: I18n.t(:alert, scope: "flash.vacation.cancel")

--- a/app/mailers/vacation_mailer.rb
+++ b/app/mailers/vacation_mailer.rb
@@ -20,4 +20,9 @@ class VacationMailer < ApplicationMailer
     @vacation = vacation
     mail(to: vacation.user.email, cc: ENV['HR_EMAIL'] )
   end
+
+  def notify_vacation_cancelled(vacation)
+    @vacation = vacation
+    mail(to: User.vacation_managers.pluck(:email), cc: ENV['HR_EMAIL'], subject: t('.subject', user: @vacation.user.name))
+  end
 end

--- a/app/views/vacation_mailer/notify_vacation_cancelled.html.erb
+++ b/app/views/vacation_mailer/notify_vacation_cancelled.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.info', user: @vacation.user.name, count: (@vacation.end_date - @vacation.start_date).to_i %></h1>
+
+<p><%= t '.dates', start_date: l(@vacation.start_date), end_date: l(@vacation.end_date)  %></p>

--- a/app/views/vacation_mailer/notify_vacation_cancelled.text.erb
+++ b/app/views/vacation_mailer/notify_vacation_cancelled.text.erb
@@ -1,0 +1,3 @@
+<%= t '.info', user: @vacation.user.name, count: (@vacation.end_date - @vacation.start_date).to_i %>
+
+<%= t '.dates', start_date: l(@vacation.start_date), end_date: l(@vacation.end_date)  %>

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -85,6 +85,10 @@ pt-BR:
       subject: "Punchclock - Pedido de férias negado"
       info: "Seu pedido de férias foi negado."
       dates: "Referente ao pedido com início em %{start_date} e término em %{end_date}"
+    notify_vacation_cancelled:
+      subject: "Punchclock - %{user} cancelou o pedido de férias"
+      info: "O %{user} cancelou o pedido de férias com duração de %{count} dias."
+      dates: "Referente ao pedido com início em %{start_date} e término em %{end_date}"
   views:
     pagination:
       first: "&laquo; Primeira"

--- a/spec/controllers/vacations_controller_spec.rb
+++ b/spec/controllers/vacations_controller_spec.rb
@@ -100,10 +100,21 @@ describe VacationsController do
     context "when vacation in cancelable" do
       let(:vacation) { create(:vacation, user: user, status: :pending) }
       let(:params) { { id: vacation.id } }
+      let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+      before do
+        allow(VacationMailer).to receive(:notify_vacation_cancelled).and_return(message_delivery)
+      end
 
       it "cancels the user vacation" do
         expect{ delete :destroy, params: params }.to change { vacation.reload.status }
         .from('pending').to('cancelled')
+      end
+
+      it "calls VacationMailer#notify_vacation_cancelled" do
+        expect(VacationMailer).to receive(:notify_vacation_cancelled)
+
+        delete :destroy, params: params
       end
 
       it "flash success message" do

--- a/spec/mailers/vacation_mailer_spec.rb
+++ b/spec/mailers/vacation_mailer_spec.rb
@@ -101,7 +101,7 @@ describe VacationMailer do
       end
     end
 
-    context 'when a vacation gets approved' do
+    context 'when a vacation gets refused' do
       let(:admins) { build_list :user, 2, :admin }
       let(:vacation) { FactoryBot.build(:vacation) }
       let(:mail) { VacationMailer.notify_vacation_denied(vacation) }
@@ -123,6 +123,64 @@ describe VacationMailer do
 
       it 'renders the sender email' do
         expect(mail.from).to eq(['do-not-reply@punchclock.com'])
+      end
+
+      it 'assigns @start_date on html_part' do
+        expect(mail.html_part.decoded).to match(l vacation.start_date)
+      end
+
+      it 'assigns @start_date on text_part' do
+        expect(mail.text_part.decoded).to match(l vacation.start_date)
+      end
+
+      it 'assigns @end_date on html_part' do
+        expect(mail.html_part.decoded).to match(l vacation.end_date)
+      end
+
+      it 'assigns @end_date on text_part' do
+        expect(mail.text_part.decoded).to match(l vacation.end_date)
+      end
+    end
+
+    context 'when a vacation is cancelled by the user' do
+      let!(:vacation_managers) { create_list :user, 2, :commercial }
+      let(:vacation) { FactoryBot.build(:vacation) }
+      let(:mail) { VacationMailer.notify_vacation_cancelled(vacation) }
+      let(:count) { "#{(vacation.end_date - vacation.start_date).to_i} dias" }
+      let(:hr_mail) { 'hr@email.com' }
+
+      it 'renders the subject' do
+        expect(mail.subject).to eq(t 'vacation_mailer.notify_vacation_cancelled.subject', user: vacation.user.name)
+      end
+
+      it 'renders the receivers emails' do
+        expect(mail.to).to eq(vacation_managers.map(&:email))
+      end
+
+      it 'renders the CC email' do
+        stub_const 'ENV', 'HR_EMAIL' => hr_mail
+
+        expect(mail.cc).to eq([hr_mail])
+      end
+
+      it 'renders the sender email' do
+        expect(mail.from).to eq(['do-not-reply@punchclock.com'])
+      end
+
+      it 'assigns @name on html_part' do
+        expect(mail.html_part.decoded).to match(vacation.user.name)
+      end
+
+      it 'assings @name on text_part' do
+        expect(mail.text_part.decoded).to match(vacation.user.name)
+      end
+
+      it 'assigns @count on html_part' do
+        expect(mail.html_part.decoded).to match(count)
+      end
+
+      it 'assigns @count on text_part' do
+        expect(mail.text_part.decoded).to match(count)
       end
 
       it 'assigns @start_date on html_part' do


### PR DESCRIPTION
Closes: #307 

### What?

- Sends an email when the user cancels a vacation to people with HR and commercial roles. It also sends as CC to HR-MAIL, added here #305.

### Related Screenshot

![image](https://user-images.githubusercontent.com/34009891/204291417-0ff232da-1734-4e37-9ebe-bf86fb096a20.png)



