### PR TITLE
FIx: City validation constraint

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
 
   belongs_to :office, optional: false
   belongs_to :mentor, class_name: :User, foreign_key: :mentor_id, optional: true
-  belongs_to :city
+  belongs_to :city, optional: true
   has_many :punches
   has_many :contributions
   has_many :allocations, dependent: :restrict_with_error


### PR DESCRIPTION
Closes: #311 

### What?
It removes the city requirement for the user. If there is a user without a city, it won't be a problem anymore and won't raise `Cidade é obrigatório(a)` again. This change won't be permanent thought



