### PR TITLE
Fix: minimum days for vacation

### DIFF
--- a/app/models/vacation.rb
+++ b/app/models/vacation.rb
@@ -54,6 +54,6 @@ class Vacation < ApplicationRecord
 
   def minimum_vacation_date
     return unless start_date
-    start_date + 5.days
+    start_date + 10.days
   end
 end


### PR DESCRIPTION
Now the user can require a vacation, as long as the vacation itself has 10 days minimum. Less than 10 days, an error is raised.

### Note

the error messages still need to be adjusted. Later on, a new pr will be opened contemplating this.

