### PR TITLE
Fix: Minimum days for vacation

### DIFF
--- a/app/controllers/vacations_controller.rb
+++ b/app/controllers/vacations_controller.rb
@@ -53,7 +53,7 @@ class VacationsController < ApplicationController
   end
 
   def alert_message(scope)
-    I18n.t(:alert, scope: [:flash, :actions, scope], resource_name: "Vacation")
+    I18n.t(:alert, scope: [:flash, :vacation, scope])
   end
 
   def errors

--- a/app/models/vacation.rb
+++ b/app/models/vacation.rb
@@ -17,7 +17,7 @@ class Vacation < ApplicationRecord
 
   validates_presence_of :start_date, :end_date, :user
   validates_comparison_of :start_date, greater_than: Date.current, if: :not_cancelled?
-  validates_comparison_of :end_date, greater_than: :minimum_vacation_date, if: :not_cancelled?
+  validate :minimum_vacation_date, if: :not_cancelled?
 
   scope :ongoing_and_scheduled, -> {
     where(status: :approved)
@@ -54,6 +54,6 @@ class Vacation < ApplicationRecord
 
   def minimum_vacation_date
     return unless start_date
-    start_date + 10.days
+    errors.add(:base, :must_be_higher_than_10) if ((end_date - start_date) < 10)
   end
 end

--- a/config/locales/pt-BR/models.yml
+++ b/config/locales/pt-BR/models.yml
@@ -55,6 +55,8 @@ pt-BR:
               uniqueness: 'O usuário já possui uma alocação em progresso'
             hourly_rate:
               invalid_currency: Moeda inválida
+        vacation:
+          must_be_higher_than_10: "As férias precisam ter no mínimo 10 dias"
     models:
       admin_user:
         one: "Administrador"

--- a/spec/models/vacation_spec.rb
+++ b/spec/models/vacation_spec.rb
@@ -72,6 +72,28 @@ RSpec.describe Vacation, type: :model do
 
       it { expect(vacation).to_not be_valid }
     end
+
+    context 'when the duration of the vacation is less than 10 days' do
+      let(:vacation) {build(:vacation, start_date: 1.day.from_now, end_date: 2.days.from_now)}
+
+      it { expect(vacation).to_not be_valid }
+
+      it 'raises an error' do
+        expect { vacation.save! }.to raise_error(ActiveRecord::RecordInvalid, 'A validação falhou: As férias precisam ter no mínimo 10 dias')
+      end
+    end
+
+    context 'when the duration of the vacation is equal to 10 days' do
+      let(:vacation) {build(:vacation, start_date: 1.day.from_now, end_date: 11.days.from_now)}
+
+      it { expect(vacation).to be_valid }
+    end
+
+    context 'when the duration of the vacation is higher than 10 days' do
+      let (:vacation) {build(:vacation, start_date: 1.day.from_now, end_date: 20.days.from_now)}
+
+      it { expect(vacation).to be_valid }
+    end
   end
 
   describe '#approve!' do


### PR DESCRIPTION
As mentioned in #318, this PR contemplates a new error message for vacations that are less than 10 days.

![image](https://user-images.githubusercontent.com/34009891/206185721-e2b35608-f239-4a84-a892-fb6c1d25de08.png)
