### PR TITLE
Fix: disable autocomplete from date picker

### DIFF
--- a/app/views/vacations/_form.html.erb
+++ b/app/views/vacations/_form.html.erb
@@ -3,11 +3,13 @@
     <div class="col-lg-8">
 
       <%= f.input :start_date, as: :string, input_html: {
+        autocomplete: :off,
         class: %i(datepicker),
         data: { holidays: current_user.office_holidays },
       } %>
 
       <%= f.input :end_date, as: :string, input_html: {
+        autocomplete: :off,
         class: %i(datepicker),
         data: { holidays: current_user.office_holidays },
       } %>


### PR DESCRIPTION
### What does this PR do?
- It disables the autocomplete from the date-picker to make it easier for the user to choose a date

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/46506018/206282854-9fef9238-65b5-4d5d-9b25-f66f77910527.png)

After:
![image](https://user-images.githubusercontent.com/46506018/206283009-43950068-08b8-4a47-bfca-95ff9c062ffa.png)
