### PR TITLE
Cancel an approved vacation request

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,7 +12,7 @@ class Ability
     can %i[edit update], User, id: user.id
     can :read, Vacation, user_id: user.id
     can :destroy, Vacation do |vacation|
-      vacation.cancelable? vacation
+      vacation.cancelable?
     end
 
     unless user.vacations.any?(&:pending?)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,7 +12,7 @@ class Ability
     can %i[edit update], User, id: user.id
     can :read, Vacation, user_id: user.id
     can :destroy, Vacation do |vacation|
-      vacation.pending? || within_cancel_range?(vacation)
+      vacation.cancelable? vacation
     end
 
     unless user.vacations.any?(&:pending?)
@@ -30,13 +30,5 @@ class Ability
     if user.admin? || user.open_source_manager?
       can :read, ActiveAdmin
     end
-  end
-
-  private
-
-  MINIMUM_DAYS_TO_CANCEL = 7
-
-  def within_cancel_range?(vacation)
-    vacation.approved? && (vacation.start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,7 +12,7 @@ class Ability
     can %i[edit update], User, id: user.id
     can :read, Vacation, user_id: user.id
     can :destroy, Vacation do |vacation|
-      vacation[:status] == :pending || within_cancel_range?(vacation)
+      vacation.pending? || within_cancel_range?(vacation)
     end
 
     unless user.vacations.any?(&:pending?)
@@ -37,6 +37,6 @@ class Ability
   MINIMUM_DAYS_TO_CANCEL = 7
 
   def within_cancel_range?(vacation)
-    vacation[:status] == :approved && ((vacation.start_date - Date.today).to_i >= MINIMUM_DAYS_TO_CANCEL)
+    vacation.approved? && (vacation.start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today)
   end
 end

--- a/app/models/vacation.rb
+++ b/app/models/vacation.rb
@@ -42,16 +42,16 @@ class Vacation < ApplicationRecord
     end
   end
 
-  def cancelable?(vacation)
-    vacation.pending? || approved_within_cancel_range?(vacation)
+  def cancelable?
+    self.pending? || approved_within_cancel_range?
   end
 
   private
 
   MINIMUM_DAYS_TO_CANCEL = 7
 
-  def approved_within_cancel_range?(vacation)
-    (vacation.start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today)
+  def approved_within_cancel_range?
+    (self.start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today)
   end
 
   def validate_approvers_and_approve

--- a/app/models/vacation.rb
+++ b/app/models/vacation.rb
@@ -42,7 +42,17 @@ class Vacation < ApplicationRecord
     end
   end
 
+  def cancelable?(vacation)
+    vacation.pending? || approved_within_cancel_range?(vacation)
+  end
+
   private
+
+  MINIMUM_DAYS_TO_CANCEL = 7
+
+  def approved_within_cancel_range?(vacation)
+    (vacation.start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today)
+  end
 
   def validate_approvers_and_approve
     update!(status: :approved) if hr_approver && commercial_approver

--- a/app/models/vacation.rb
+++ b/app/models/vacation.rb
@@ -43,7 +43,7 @@ class Vacation < ApplicationRecord
   end
 
   def cancelable?
-    self.pending? || approved_within_cancel_range?
+    pending? || approved_within_cancel_range?
   end
 
   private
@@ -51,7 +51,7 @@ class Vacation < ApplicationRecord
   MINIMUM_DAYS_TO_CANCEL = 7
 
   def approved_within_cancel_range?
-    (self.start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today)
+    start_date.days_ago(MINIMUM_DAYS_TO_CANCEL) >= Date.today
   end
 
   def validate_approvers_and_approve

--- a/spec/features/admin/allocation_chart_spec.rb
+++ b/spec/features/admin/allocation_chart_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe 'Admin Allocation chart', type: :feature do
+  next_month_date = Date.today.next_month
   let(:admin_user) { create(:user, :admin, occupation: :administrative) }
 
   before do
@@ -14,7 +15,7 @@ describe 'Admin Allocation chart', type: :feature do
     let!(:user) { create(:user, allocations: [allocation]) }
 
     let(:allocation) do
-      build(:allocation, project: project, start_at: Date.new(2022, 5, 1), end_at: Date.new(2022, 11, 1), ongoing: true)
+      build(:allocation, project: project, start_at: Date.today.prev_month, end_at: next_month_date, ongoing: true)
     end
 
     before { visit '/admin/allocation_chart' }
@@ -48,7 +49,8 @@ describe 'Admin Allocation chart', type: :feature do
 
         it '"Alocado até" column links to allocation' do
           within 'tbody' do
-            expect(page).to have_link('01/11/2022', href: "/admin/allocations/#{allocation.id}")
+            formatted_date = next_month_date.strftime('%d/%m/%Y')
+            expect(page).to have_link(formatted_date, href: "/admin/allocations/#{allocation.id}")
           end
         end
       end

--- a/spec/features/admin/allocation_chart_spec.rb
+++ b/spec/features/admin/allocation_chart_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Admin Allocation chart', type: :feature do
-  next_month_date = Date.today.next_month
+  let(:next_month_date) { Date.today.next_month }
   let(:admin_user) { create(:user, :admin, occupation: :administrative) }
 
   before do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -36,9 +36,9 @@ describe 'User' do
     describe 'when status is approved' do
       let!(:vacation) do
         create(:vacation, {
-          status: :approved,
-          start_date: Date.tomorrow
-        }
+            status: :approved,
+            start_date: Date.tomorrow
+          }
         )
       end
 
@@ -55,7 +55,7 @@ describe 'User' do
       end
 
       it 'does not allow the user to cancel a vacation after it started' do
-        travel_to Date.current + 2.days
+        travel_to 2.days.from_now
 
         is_expected.not_to be_able_to(:destroy, vacation)
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -25,4 +25,34 @@ describe 'User' do
       it { is_expected.not_to be_able_to(:update, User.new) }
     end
   end
+
+  describe 'vacations abilities' do
+    describe 'when status is pending' do
+      context 'allows user to cancel a vacation' do
+        it { is_expected.to be_able_to(:destroy, Vacation.new) }
+      end
+    end
+
+    describe 'when status is approved' do
+      let(:vacation) do
+        create(:vacation, {
+            status: :approved,
+            start_date: Date.new(2022, 12, 27)
+          }
+        )
+      end
+
+      it 'does not allow the user to cancel a vacation less than 7 days ahead of time' do
+        allow(Date).to receive(:today).and_return(Date.new(2022, 12, 21))
+
+         is_expected.not_to be_able_to(:destroy, vacation)
+      end
+
+      it 'allows user the user to cancel a vacation more than 7 days ahead of time' do
+        allow(Date).to receive(:today).and_return(Date.new(2022, 12, 20))
+
+        is_expected.to be_able_to(:destroy, vacation)
+      end
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -35,11 +35,7 @@ describe 'User' do
 
     describe 'when status is approved' do
       let!(:vacation) do
-        create(:vacation, {
-            status: :approved,
-            start_date: Date.tomorrow
-          }
-        )
+        create(:vacation, status: :approved, start_date: Date.tomorrow)
       end
 
       it 'does not allow the user to cancel a vacation less than 7 days ahead of time' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -34,28 +34,28 @@ describe 'User' do
     end
 
     describe 'when status is approved' do
-      let(:vacation) do
+      let!(:vacation) do
         create(:vacation, {
-            status: :approved,
-            start_date: Date.current.next_day
-          }
+          status: :approved,
+          start_date: Date.tomorrow
+        }
         )
       end
 
       it 'does not allow the user to cancel a vacation less than 7 days ahead of time' do
-        allow(Date).to receive(:today).and_return(Date.current - 5)
+        travel_to 5.days.ago
 
         is_expected.not_to be_able_to(:destroy, vacation)
       end
 
       it 'allows user the user to cancel a vacation more than 6 days ahead of time' do
-        allow(Date).to receive(:today).and_return(Date.current - 6)
+        travel_to 6.days.ago
 
         is_expected.to be_able_to(:destroy, vacation)
       end
 
       it 'does not allow the user to cancel a vacation after it started' do
-        allow(Date).to receive(:today).and_return(Date.current + 2)
+        travel_to Date.current + 2.days
 
         is_expected.not_to be_able_to(:destroy, vacation)
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -37,21 +37,27 @@ describe 'User' do
       let(:vacation) do
         create(:vacation, {
             status: :approved,
-            start_date: Date.new(2022, 12, 27)
+            start_date: Date.current.next_day
           }
         )
       end
 
       it 'does not allow the user to cancel a vacation less than 7 days ahead of time' do
-        allow(Date).to receive(:today).and_return(Date.new(2022, 12, 21))
+        allow(Date).to receive(:today).and_return(Date.current - 5)
 
-         is_expected.not_to be_able_to(:destroy, vacation)
+        is_expected.not_to be_able_to(:destroy, vacation)
       end
 
-      it 'allows user the user to cancel a vacation more than 7 days ahead of time' do
-        allow(Date).to receive(:today).and_return(Date.new(2022, 12, 20))
+      it 'allows user the user to cancel a vacation more than 6 days ahead of time' do
+        allow(Date).to receive(:today).and_return(Date.current - 6)
 
         is_expected.to be_able_to(:destroy, vacation)
+      end
+
+      it 'does not allow the user to cancel a vacation after it started' do
+        allow(Date).to receive(:today).and_return(Date.current + 2)
+
+        is_expected.not_to be_able_to(:destroy, vacation)
       end
     end
   end


### PR DESCRIPTION
Closes #332 

### What does this PR do?
- It allows a user to cancel an approved vacation before 7 days it started