### PR TITLE
feat: allow admin to resend the user reg email through admin

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,6 +12,12 @@ class NotificationMailer < ActionMailer::Base
     mail(to: @user.email, subject: 'Welcome to Punchclock')
   end
 
+  def resend_user_registration(user, token)
+    @user = user
+    @token = token
+    mail(to: @user.email, subject: 'Welcome to Punchclock', template_name: 'notify_user_registration')
+  end
+
   def notify_user_password_change(user, new_password)
     @user = user
     @new_password = new_password

--- a/config/locales/pt-BR/models.yml
+++ b/config/locales/pt-BR/models.yml
@@ -182,6 +182,7 @@ pt-BR:
         started_at: "Iniciou em"
         mentor: "Mentor"
         mentees: "Mentorados"
+        user_registration: 'Cadastro de Usuário'
         overall_score: "Pontuação Geral"
         performance_score: "Pontuação de Desempenho"
         english_level: "Nível de Inglês"

--- a/config/locales/pt-BR/pt-BR.yml
+++ b/config/locales/pt-BR/pt-BR.yml
@@ -26,6 +26,8 @@ pt-BR:
   english_evaluations: 'Avaliações de Inglês'
   hour_report_curent_month: 'Report de Horas do mês atual'
   hour_report_past_month: 'Report de Horas do mês anterior'
+  resend_user_registration: 'Reenviar Email de Cadastro'
+  resend_user_registration_confirmed: 'Email de Cadastro Reenviado'
   not_evaluated: 'Não avaliado'
   not_allocated: 'Não alocado'
   allocated: 'Alocado'

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -220,5 +220,34 @@ describe NotificationMailer do
         expect(mail.body).to match(contributions)
       end
     end
+
+    context 'when a registration email is sent again through admin' do
+      let(:user) { create(:user, name: "Art Vandelay") }
+      let(:mail) { NotificationMailer.resend_user_registration(user, 'xyz') }
+
+      it 'renders the subject' do
+        expect(mail.subject).to eq('Welcome to Punchclock')
+      end
+
+      it 'renders the receiver email' do
+        expect(mail.to).to eq([user.email])
+      end
+
+      it 'renders the sender email' do
+        expect(mail.from).to eq(['do-not-reply@punchclock.com'])
+      end
+
+      it 'assigns @name' do
+        expect(mail.body.encoded).to match(user.name)
+      end
+
+      it 'assigns @email' do
+        expect(mail.body.encoded).to match(user.email)
+      end
+
+      it 'assigns link to edit user password path' do
+        expect(mail.body.encoded).to have_link('here', href: edit_user_password_url(reset_password_token: 'xyz'))
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds link on the User's admin show page that allows to resend the user's registration email.

![image](https://user-images.githubusercontent.com/33486409/225935182-247fe69f-d75c-488a-90f0-a62ec7069ed2.png)![image](https://user-images.githubusercontent.com/33486409/225741007-d50d3f63-3720-488b-a7bd-6f6205e50b75.png)
