### PR TITLE
Fix: allocation chart sorting by user name

### DIFF
--- a/app/assets/javascripts/active_admin/allocation_chart.js
+++ b/app/assets/javascripts/active_admin/allocation_chart.js
@@ -15,10 +15,6 @@ $(document).ready(function () {
         targets: hiddenTimeColumnPosition,
         type: 'num',
         visible: false
-      },
-      {
-        targets: nameColumnPosition,
-        orderData: hiddenTimeColumnPosition
       }
     ]
   });

--- a/app/assets/javascripts/active_admin/allocation_chart.js
+++ b/app/assets/javascripts/active_admin/allocation_chart.js
@@ -1,7 +1,6 @@
 $(document).ready(function () {
   const dateColumnPosition = 2
   const hiddenTimeColumnPosition = 7
-  const nameColumnPosition = 0
   
   $('#allocations_chart').DataTable({
     paging: false,


### PR DESCRIPTION
Fixes #373 
The previous code inside `app/assets/javascripts/active_admin/allocation_chart.js` was defining a rule for `name` column to be sorted based on `hiddenTime` column. This fix removes the rule to allow `name` column to sort user names correctly. 
