### PR TITLE
feat: list user talks on experience tab

### DIFF
--- a/app/admin/talk.rb
+++ b/app/admin/talk.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Talk do
+  decorate_with TalkDecorator
+
   permit_params :event_name, :talk_title, :date, :user_id
 
   menu parent: User.model_name.human(count: 2)
@@ -13,8 +15,9 @@ ActiveAdmin.register Talk do
   filter :date
 
   form do |f|
+    user = f.object.user_id || params[:user_id]
     f.inputs do
-      f.input :user, as: :select, collection: User.active.order(:name)
+      f.input :user, as: :select, collection: User.active.order(:name), selected: user
       f.input :event_name
       f.input :talk_title
       f.input :date, as: :datetime_picker

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -203,6 +203,17 @@ ActiveAdmin.register User do
         end
 
         panel I18n.t('talking_presenting_experience') do
+          table_for user.talks.decorate, i18n: Talk do
+            column :event_name
+            column :talk_title
+            column :date
+          end
+
+          span do
+            link_to I18n.t('active_admin.new_model', model: Talk.model_name.human),
+              new_admin_talk_path(user_id: user),
+              class: "button"
+          end
         end
       end
     end

--- a/app/decorators/talk_decorator.rb
+++ b/app/decorators/talk_decorator.rb
@@ -1,0 +1,7 @@
+class TalkDecorator < Draper::Decorator
+  delegate_all
+
+  def date
+    model.date.to_date.to_fs(:date)
+  end
+end

--- a/config/locales/pt-BR/models.yml
+++ b/config/locales/pt-BR/models.yml
@@ -242,7 +242,9 @@ pt-BR:
         user: "Usuário"
         event_name: "Nome do evento"
         talk_title: "Título da palestra"
-        date: "data"
+        date: "Data"
+        created_at: "Criado em"
+        updated_at: "Atualizado em"
       regional_holiday:
         id: "ID"
         name: "Nome"

--- a/config/locales/pt-BR/pt-BR.yml
+++ b/config/locales/pt-BR/pt-BR.yml
@@ -28,7 +28,7 @@ pt-BR:
   professional_experience: 'Experiência profissional'
   educational_experience: 'Experiência educacional'
   open_source_experience: 'Experiência open-source'
-  talking_presenting_experience: 'Experiência apresentando palestra'
+  talking_presenting_experience: 'Experiência Apresentando Palestras'
   hour_report_curent_month: 'Report de Horas do mês atual'
   hour_report_past_month: 'Report de Horas do mês anterior'
   resend_user_registration: 'Reenviar Email de Cadastro'

--- a/spec/decorators/talk_decorator_spec.rb
+++ b/spec/decorators/talk_decorator_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe TalkDecorator do
+  describe '#date' do
+    subject { described_class.new(talk).date }
+
+    let(:talk) { build_stubbed(:talk, date: DateTime.parse('2022-08-26T16:50')) }
+
+    it { is_expected.to eq '26/08/2022' }
+  end
+end

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :talk do
-    event_name { 'some name' }
-    talk_title { 'some trile' }
-    date { Date.today }
+    event_name { Faker::Lorem.sentence }
+    talk_title { Faker::Lorem.sentence }
+    date { Faker::Date.between(from: 5.year.ago, to: 1.day.ago) }
     user
 
     trait :invalid_talk do

--- a/spec/features/admin/talks_spec.rb
+++ b/spec/features/admin/talks_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Talks', type: :feature do
+  let(:admin_user) { create(:user, :admin, occupation: :administrative) }
+  let!(:user)      { create(:user, :admin) }
+  let!(:another_user)      { create(:user) }
+  let!(:talks) { create_list(:talk, 15) }
+  let!(:talk) { create(:talk, user: user).decorate }
+
+  before do
+    sign_in(admin_user)
+    visit '/admin/talks'
+  end
+
+  describe 'Index' do
+    it 'must find fields "User", "Event Name", "Talk Title" and "Date" on table' do
+      within 'table' do
+        expect(page).to have_text('Nome do evento') &
+                        have_text('Título da palestra') &
+                        have_text('Data') &
+                        have_text('Usuário') &
+                        have_text('Criado em') &
+                        have_text('Atualizado em')
+      end
+    end
+  end
+
+  describe 'Filters' do
+    it 'by user' do
+      within '#filters_sidebar_section' do
+        expect(page).to have_select('Usuário', options: User.all.pluck(:name) << 'Qualquer')
+        select user.name, from: 'Usuário'
+        click_button 'Filtrar'
+      end
+
+      within 'table' do
+        expect(page).to have_content(user.name)
+      end
+
+      within '#filters_sidebar_section' do
+        click_link 'Limpar Filtros'
+        select another_user.name, from: 'Usuário'
+        click_button 'Filtrar'
+      end
+
+      expect(page).to have_content('Nenhum(a) Palestras encontrado(a)')
+    end
+
+    it 'by event name' do
+      within '#filters_sidebar_section' do
+        fill_in 'q_event_name', with: talk.event_name
+        click_button 'Filtrar'
+      end
+
+      within 'table' do
+        expect(page).to have_content(talk.event_name)
+      end
+
+      within '#filters_sidebar_section' do
+        click_link 'Limpar Filtros'
+        fill_in 'q_event_name', with: "teste"
+        click_button 'Filtrar'
+      end
+
+      expect(page).to have_content('Nenhum(a) Palestras encontrado(a)')
+    end
+
+    it 'by talk title' do
+      within '#filters_sidebar_section' do
+        fill_in 'q_talk_title', with: talk.talk_title
+        click_button 'Filtrar'
+      end
+
+      within 'table' do
+        expect(page).to have_content(talk.talk_title)
+      end
+
+      within '#filters_sidebar_section' do
+        click_link 'Limpar Filtros'
+        fill_in 'q_talk_title', with: "teste"
+        click_button 'Filtrar'
+      end
+
+      expect(page).to have_content('Nenhum(a) Palestras encontrado(a)')
+    end
+
+    let!(:older_talk) { create(:talk, user: user, date: 10.years.ago).decorate }
+
+    it 'by talk date' do
+      within '#filters_sidebar_section' do
+        fill_in 'q[date_gteq_datetime]', with: talk.date
+        click_button 'Filtrar'
+      end
+
+      within 'table' do
+        expect(page).to have_content(talk.talk_title)
+        expect(page).to_not have_content(older_talk.talk_title)
+      end
+
+      within '#filters_sidebar_section' do
+        click_link 'Limpar Filtros'
+        fill_in 'q[date_gteq_datetime]', with: Date.today
+        click_button 'Filtrar'
+      end
+
+      expect(page).to have_content('Nenhum(a) Palestras encontrado(a)')
+    end
+  end
+
+  describe 'Actions' do
+    describe 'New' do
+      before do
+        visit '/admin/talks'
+        click_link 'Novo(a) Palestra'
+      end
+
+      it 'must have the form working' do
+        find('#talk_user_id').find(:option, user.name).select_option
+        find('#talk_event_name').fill_in with: 'Ruby Conf'
+        find('#talk_talk_title').fill_in with: 'My Presentation'
+        find('#talk_date').fill_in with: 2.months.ago
+
+        click_button 'Criar Palestra'
+
+        expect(page).to have_text('Palestra foi criado com sucesso.') &
+                        have_text(user.name) &
+                        have_text('Ruby Conf') &
+                        have_text('My Presentation')
+      end
+    end
+
+    describe 'Show' do
+      before do
+        visit '/admin/talks'
+        within 'table' do
+          find_link('Visualizar', href: "/admin/talks/#{talk.id}").click
+        end
+      end
+
+      it 'have edit action' do
+        expect(page).to have_link('Editar Palestra')
+      end
+
+      it 'have delete action' do
+        expect(page).to have_link('Remover Palestra')
+      end
+
+      it 'must have labels' do
+        within '.attributes_table.talk' do
+          expect(page).to have_text('Nome do evento') &
+                          have_text('Título da palestra') &
+                          have_text('Data') &
+                          have_text('Usuário') &
+                          have_text('Criado em') &
+                          have_text('Atualizado em')
+        end
+      end
+
+      it 'have user table with correct information' do
+        expect(page).to   have_text(talk.event_name) &
+                          have_text(talk.talk_title) &
+                          have_text(talk.date)
+      end
+    end
+
+    describe 'Edit' do
+      before do
+        visit "/admin/talks/#{talk.id}"
+        click_link('Editar Palestra')
+      end
+
+      it 'must have labels' do
+        within 'form' do
+          expect(page).to have_text('Nome do evento') &
+                          have_text('Título da palestra') &
+                          have_text('Data') &
+                          have_text('Usuário')
+        end
+      end
+
+      it 'updates talk information' do
+        find('#talk_event_name').fill_in with: 'Rails Conf'
+
+        click_button 'Atualizar Palestra'
+
+        expect(page).to have_css('.flash_notice', text: 'Palestra foi atualizado com sucesso.') &
+                        have_text('Rails Conf') &
+                        have_text(talk.talk_title)
+      end
+    end
+
+    describe 'Destroy' do
+      let!(:another_talk) { create(:talk, user: another_user) }
+
+      it 'cancel delete talk', js: true do
+        visit "/admin/talks/#{another_talk.id}"
+
+        page.dismiss_confirm do
+          find_link("Remover Palestra", href: "/admin/talks/#{another_talk.id}").click
+        end
+
+        expect(current_path).to eql("/admin/talks/#{another_talk.id}")
+      end
+
+      it 'confirm delete talk', js: true do
+        visit "/admin/talks/#{another_talk.id}"
+
+        page.accept_confirm do
+          find_link("Remover Palestra", href: "/admin/talks/#{another_talk.id}").click
+        end
+
+        expect(page).to have_text('Palestra foi deletado com sucesso.') &
+                        have_no_link(talk.event_name, href: "/admin/talks/#{talk.id}")
+      end
+    end
+  end
+end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -269,6 +269,7 @@ describe 'Users', type: :feature do
 
       context 'on Experience tab' do
         let!(:contribution) { create(:contribution, user: user).decorate }
+        let!(:talk) { create(:talk, user: user).decorate }
 
         before { refresh }
         it 'finds all elements correctly' do
@@ -278,6 +279,14 @@ describe 'Users', type: :feature do
                             have_css('.col.col-name', text: contribution.repository.name) &
                             have_css('.col.col-description', text: contribution.description)
                             have_css('.col.col-created_at', text: contribution.created_at)
+
+            expect(page).to have_table('') &
+                            have_text('Experiência Apresentando Palestras') &
+                            have_css('.col.col-event_name', text: talk.event_name) &
+                            have_css('.col.col-talk_title', text: talk.talk_title) &
+                            have_css('.col.col-date', text: talk.date)
+
+            expect(page).to have_link('Novo(a) Palestra')
           end
         end
       end


### PR DESCRIPTION
- Adds a table in the presenting experience panel to list users talks 
- Also adds feature tests for admin/talks

![image](https://github.com/Codeminer42/Punchclock/assets/95383700/0c567380-0449-4134-a6a4-1f490fe70dd9)

Closes #407 