### PR TITLE
feat: notify users about contributions waiting for description

### DIFF
--- a/app/jobs/alert_fill_contribution_description_job.rb
+++ b/app/jobs/alert_fill_contribution_description_job.rb
@@ -1,0 +1,12 @@
+class AlertFillContributionDescriptionJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id)
+    user = User.find(user_id)
+    contributions = user.contributions.received 
+
+    unless contributions.empty?
+      NotificationMailer.notify_fill_contribution_description(user, contributions.length).deliver_later
+    end
+  end
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -58,4 +58,10 @@ class NotificationMailer < ActionMailer::Base
     newsletter_email = ENV['NEWS_EMAIL']
     mail(to: newsletter_email, subject: 'Punchlock - Contribuições aprovadas')
   end
+
+  def notify_fill_contribution_description(user, contributions_total)
+    @user = user
+    @contributions_total = contributions_total 
+    mail(to: @user.email, subject: t('notification_mailer.subject.notify_fill_contribution_description_html'))
+  end
 end

--- a/app/services/github/contributions/create.rb
+++ b/app/services/github/contributions/create.rb
@@ -20,6 +20,11 @@ module Github
               result.pr_state
             )
           end
+
+        collect_all_contributions.map(&:user_id).uniq
+          .map do |user_id|
+            AlertFillContributionDescriptionJob.perform_later(user_id)
+          end
       end
 
       private

--- a/app/views/notification_mailer/notify_fill_contribution_description.html.erb
+++ b/app/views/notification_mailer/notify_fill_contribution_description.html.erb
@@ -1,0 +1,7 @@
+<%= 
+  t('notification_mailer.notify_fill_contribution_description_html',
+    host: ENV['HOST'],
+    contributions_total: @contributions_total,
+    contributions_link: link_to("Acessar PRs", contributions_url)
+   ) 
+ %>

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -28,6 +28,8 @@ pt-BR:
     form:
       submit: 'Salvar Revisão'
   notification_mailer:
+    subject: 
+      notify_fill_contribution_description_html: 'Punchlock - Contribuições Aguardando Descrição'
     body_html: |
       <p>
         Pessoal,
@@ -54,6 +56,17 @@ pt-BR:
       </p>
       <p>
         E avisem hora extra para <strong>"rh@codeminer42.com"</strong>
+      </p>
+      Abs
+    notify_fill_contribution_description_html: |
+      <p>
+        Olá,
+      </p>
+      <p>
+        Você possui %{contributions_total} contribuições aguardando descrição da PR.
+      </p>
+      <p>
+        %{contributions_link}
       </p>
       Abs
     notify_admin_extra_hour:

--- a/spec/jobs/alert_fill_contribution_description_job_spec.rb
+++ b/spec/jobs/alert_fill_contribution_description_job_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe AlertFillContributionDescriptionJob, type: :job do
+  describe "#perform" do
+    let(:user) { create(:user) }
+
+    context "when user has received contributions" do
+      let(:contributions) { create_list(:contribution, 3, user: user) }
+      it "sends a notification email when user has received contributions" do
+        expect(NotificationMailer).to receive(:notify_fill_contribution_description).with(user, contributions.length).and_return(double(deliver_later: true))
+        
+        perform_enqueued_jobs do
+          described_class.perform_later(user.id)
+        end
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+    end
+
+    context "when user has no received contributions" do
+      let(:user) { create(:user) }
+      let(:contributions) { create_list(:contribution, 3, :approved, user: user) }
+      it "does not send a notification email when user has no received contributions" do
+        expect(NotificationMailer).not_to receive(:notify_fill_contribution_description)
+        
+        perform_enqueued_jobs do
+          described_class.perform_later(user.id)
+        end
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+    end
+  end
+end
+

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -249,5 +249,31 @@ describe NotificationMailer do
         expect(mail.body.encoded).to have_link('here', href: edit_user_password_url(reset_password_token: 'xyz'))
       end
     end
+
+    context 'when notify user to fill contribution description' do
+      let(:user) { create(:user) }
+      let!(:contributions) { FactoryBot.create_list(:contribution, 5, user: user) }
+      let(:mail) { NotificationMailer.notify_fill_contribution_description(user, contributions.length) }
+
+      it 'renders the subject' do
+        expect(mail.subject).to eq('Punchlock - Contribuições Aguardando Descrição')
+      end
+
+      it 'renders the receiver email' do
+        expect(mail.to).to eq([user.email])
+      end
+
+      it 'renders the sender email' do
+        expect(mail.from).to eq(['do-not-reply@punchclock.com'])
+      end
+
+      it 'renders the total of contributions' do
+        expect(mail.body.encoded).to match('5')
+      end
+
+      it 'renders the contribution link' do
+        expect(mail.body.encoded).to have_link('Acessar PRs', href: contributions_url)
+      end
+    end
   end
 end

--- a/spec/services/github/contributions/create_spec.rb
+++ b/spec/services/github/contributions/create_spec.rb
@@ -4,16 +4,73 @@ require 'rails_helper'
 
 RSpec.describe Github::Contributions::Create, type: :service do
   include EnvHelper
+  include ActiveJob::TestHelper
 
   around do |example|
     with_temp_env('GITHUB_OAUTH_TOKEN' => 'github-api-token', &example)
   end
 
+
   describe '#call' do
-    subject(:call) { described_class.new(client: client).call }
+    subject(:call_create) { described_class.new(client: client).call }
 
-    let(:client) { instance_double('Github') }
+    let(:client) { instance_double(Github::Client) }
 
-    # TODO: Add specs to cover all use cases
+    context 'when there are contributions to create' do
+      let(:contributions) do
+        [
+          instance_double(Github::Contributions::Wrappers::PullRequest,
+            user_id: 1,
+            repository_id: 1,
+            pull_request_url: 'http://github.com/owner/repo/pull/123',
+            created_at: Time.now,
+            pr_state: 'open'
+          ),
+          instance_double(Github::Contributions::Wrappers::PullRequest,
+            user_id: 2,
+            repository_id: 2,
+            pull_request_url: 'http://github.com/owner/repo2/pull/456',
+            created_at: Time.now,
+            pr_state: 'closed'
+          )
+        ]
+      end
+
+      before do
+        allow_any_instance_of(Github::Contributions::Collect).to receive(:all).and_return(contributions)
+        allow(Contribution).to receive(:find_or_create_by).and_call_original
+      end
+
+      it 'creates contributions using find_or_create_by' do
+        expect(Contribution).to receive(:find_or_create_by).twice
+        call_create
+      end
+
+      it 'enqueues AlertFillContributionDescriptionJob for each user' do
+        perform_enqueued_jobs do
+          expect(AlertFillContributionDescriptionJob).to receive(:perform_later).with(1).once
+          expect(AlertFillContributionDescriptionJob).to receive(:perform_later).with(2).once
+          call_create
+        end
+      end
+    end
+
+    context 'when there are no contributions to create' do
+      before do
+        allow_any_instance_of(Github::Contributions::Collect).to receive(:all).and_return([])
+      end
+
+      it 'does not create any contributions' do
+        expect(Contribution).not_to receive(:find_or_create_by)
+        call_create
+      end
+
+      it 'does not enqueue AlertFillContributionDescriptionJob' do
+        perform_enqueued_jobs do
+          expect(AlertFillContributionDescriptionJob).not_to receive(:perform_later)
+          call_create
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a feature to send emails to users after a contribution is approved to request a description for it.


Closes #413 