### PR TITLE
fix: error violating unique constraint when seeding holidays

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,7 @@ def create_holiday(city:)
   holiday = RegionalHoliday.find_or_create_by!(day: random_date.day, month: random_date.month) do |holiday|
     holiday.name = "#{Faker::Name.name} day"
   end
-  holiday.cities << city
+  holiday.cities << city unless holiday.cities.exists?(city.id)
 end
 
 def create_user(number:)


### PR DESCRIPTION
As holidays are associated with randomly created cities, there is a chance that the same city will be selected more than once, which generates an `ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint
"index_cities_on_regional_holidays"`.

An example can be seen in this broken run of the `test` job in the CI: https://github.com/Codeminer42/Punchclock/actions/runs/5178825930/jobs/9330828836#step:9:193

Solving this problem by checking if the city is already associated with the holiday.