### PR TITLE
Fix regressions in new admin pages

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -142,7 +142,7 @@ ActiveAdmin.register User do
         end
       end
 
-      tab I18n.t('perfomance_evaluations') do
+      tab I18n.t('performance_evaluations') do
         attributes_table do
           row :evaluation do
             table_for user.evaluations.by_kind(:performance).order(created_at: :desc) do

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -81,25 +81,7 @@ class UserDecorator < Draper::Decorator
     model.mentor.first_and_last_name
   end
 
-  def allow_overtime
-    I18n.t(model.allow_overtime) || 'N/A'
-  end
-
-  def active
-    I18n.t(model.active) || 'N/A'
-  end
-
-  def started_at
-    return if model.started_at.nil?
-    I18n.l(user.started_at)
-  end
-
   def office_city
     model.office.city
-  end
-
-  def otp_required_for_login
-    return I18n.t('false') if model.otp_required_for_login.nil?
-    I18n.t(model.otp_required_for_login)
   end
 end

--- a/app/views/new_admin/users/_details.html.erb
+++ b/app/views/new_admin/users/_details.html.erb
@@ -45,7 +45,7 @@
           <td class="px-4 py-3">
             <div class="flex items-center text-sm">
               <p class="text-sm text-gray-600 dark:text-gray-400 font-semibold">
-                <%= user.otp_required_for_login %>
+                <%= t(user.otp_required_for_login?) %>
               </p>
             </div>
           </td>
@@ -279,7 +279,7 @@
           <td class="px-4 py-3">
             <div class="flex items-center text-sm">
               <p class="text-sm text-gray-600 dark:text-gray-400 font-semibold">
-                <%= user.allow_overtime %>
+                <%= t(user.allow_overtime?) %>
               </p>
             </div>
           </td>
@@ -293,7 +293,7 @@
           <td class="px-4 py-3">
             <div class="flex items-center text-sm">
               <p class="text-sm text-gray-600 dark:text-gray-400 font-semibold">
-                <%= user.active %>
+                <%= t(user.active?) %>
               </p>
             </div>
           </td>
@@ -307,7 +307,7 @@
           <td class="px-4 py-3">
             <div class="flex items-center text-sm">
               <p class="text-sm text-gray-600 dark:text-gray-400 font-semibold">
-                <%= user.started_at %>
+                <%= l(user.started_at) if user.started_at.present? %>
               </p>
             </div>
           </td>

--- a/spec/controllers/new_admin/users_controller_spec.rb
+++ b/spec/controllers/new_admin/users_controller_spec.rb
@@ -32,7 +32,7 @@ describe NewAdmin::UsersController do
 
       expect(page).to have_content(user.name)
                   .and have_content(user.email)
-                  .and have_content(user.otp_required_for_login)
+                  .and have_content(I18n.t(user.otp_required_for_login?))
                   .and have_content(user.github)
                   .and have_content(user.office_city)
     end


### PR DESCRIPTION
#388 added some changes to `user_decorator.rb` that broke the following specs:
- `spec/features/admin/users_spec.rb:121`
- `specs/spreadsheets/admins_spreadsheets_spec.rb`
- `spec/features/edit_user_spec.rb:50`
- `spec/features/dashboard_spec.rb:81`

Fixed by moving some logic from the decorator to the `new_admin/users#show` view.

#402 fixed a typo in the translations key that broke the following spec:
- `spec/features/admin/users_spec.rb:249`

All tests are passing now.