### PR TITLE
Fix flaky test in `allocation_chart_helper_spec.rb`

### DIFF
--- a/spec/helpers/active_admin/allocation_chart_helper_spec.rb
+++ b/spec/helpers/active_admin/allocation_chart_helper_spec.rb
@@ -44,7 +44,7 @@ module ActiveAdmin
       end
 
       context 'when last allocation end date has passed' do
-        let(:last_allocation) { create(:allocation, end_at: current_date) }
+        let(:last_allocation) { create(:allocation, start_at: current_date - 10.days, end_at: current_date) }
         it 'returns EXPIRED' do
           is_expected.to eq(AllocationChartHelper::Status::EXPIRED)
         end


### PR DESCRIPTION
This PR ensures that the test setup consistently creates valid allocations when utilizing time travel. The specific test in question fails due to the factory sometimes generating an allocation with today's date. This occurs when the `rand(0..180)` call returns `0` at this line:
https://github.com/Codeminer42/Punchclock/blob/287cde734cb3cfa2522a57d20d5034e1be60585d/spec/factories/allocations.rb#L8

In the test setup, `#travel_to` is used to move to a future date, causing `Date.today` to return that future date. When combined with `rand(0..180)` returning `0`, the allocation's `start_at` is set to the future date.
The issue arises when that same future date is used as `end_at` at this line:
https://github.com/Codeminer42/Punchclock/blob/287cde734cb3cfa2522a57d20d5034e1be60585d/spec/helpers/active_admin/allocation_chart_helper_spec.rb#L47 
To fix that, this PR adds a fixed `start_at` date in the test setup. Ensuring that the `start_at` date will not equal the `end_at` date.

Fixes #476.