### PR TITLE
Fix `tailwindcss:watch` failing to start in Docker container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - REDIS_URL=redis://redis:6379/
       - REDIS_PROVIDER=REDIS_URL
       - DB_HOST=database
+    tty: true
 
   database:
     image: postgres:13


### PR DESCRIPTION
When trying to run the project with the following command:
```
$ docker compose up
```
I would get the following error from the `app` container:
```
punchclock-app-1       | 13:44:16 rails.1  | started with pid 7
punchclock-app-1       | 13:44:16 worker.1 | started with pid 8
punchclock-app-1       | 13:44:16 css.1    | started with pid 9
punchclock-app-1       | 13:44:18 rails.1  | => Booting Puma
punchclock-app-1       | 13:44:18 rails.1  | => Rails 7.0.6 application starting in development 
punchclock-app-1       | 13:44:18 rails.1  | => Run `bin/rails server --help` for more startup options
punchclock-app-1       | 13:44:18 rails.1  | [7] Puma starting in cluster mode...
punchclock-app-1       | 13:44:18 rails.1  | [7] * Puma version: 6.3.0 (ruby 3.1.4-p223) ("Mugi No Toki Itaru")
punchclock-app-1       | 13:44:18 rails.1  | [7] *  Min threads: 5
punchclock-app-1       | 13:44:18 rails.1  | [7] *  Max threads: 5
punchclock-app-1       | 13:44:18 rails.1  | [7] *  Environment: development
punchclock-app-1       | 13:44:18 rails.1  | [7] *   Master PID: 7
punchclock-app-1       | 13:44:18 rails.1  | [7] *      Workers: 2
punchclock-app-1       | 13:44:18 rails.1  | [7] *     Restarts: (✔) hot (✖) phased
punchclock-app-1       | 13:44:18 rails.1  | [7] * Preloading application
punchclock-app-1       | 13:44:18 rails.1  | [7] * Listening on http://0.0.0.0:3000
punchclock-app-1       | 13:44:18 rails.1  | [7] Use Ctrl-C to stop
punchclock-app-1       | 13:44:18 rails.1  | [7] - Worker 0 (PID: 62) booted in 0.02s, phase: 0
punchclock-app-1       | 13:44:18 rails.1  | [7] - Worker 1 (PID: 67) booted in 0.02s, phase: 0
punchclock-app-1       | 13:44:18 worker.1 | 2023-07-19T13:44:18.940Z pid=8 tid=qtw INFO: Booted Rails 7.0.6 application in development environment
punchclock-app-1       | 13:44:18 worker.1 | 2023-07-19T13:44:18.940Z pid=8 tid=qtw INFO: Running in ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [x86_64-linux]
punchclock-app-1       | 13:44:18 worker.1 | 2023-07-19T13:44:18.940Z pid=8 tid=qtw INFO: See LICENSE and the LGPL-3.0 for licensing details.
punchclock-app-1       | 13:44:18 worker.1 | 2023-07-19T13:44:18.940Z pid=8 tid=qtw INFO: Upgrade to Sidekiq Pro for more features and support: https://sidekiq.org
punchclock-app-1       | 13:44:18 worker.1 | 2023-07-19T13:44:18.941Z pid=8 tid=qtw INFO: Booting Sidekiq 6.5.9 with Sidekiq::RedisConnection::RedisAdapter options {:url=>"redis://redis:6379/"}
punchclock-app-1       | 13:44:19 css.1    | exited with code 0
punchclock-app-1       | 13:44:19 system   | sending SIGTERM to all processes
punchclock-app-1       | 13:44:19 rails.1  | [7] === puma shutdown: 2023-07-19 13:44:19 +0000 ===
punchclock-app-1       | 13:44:19 worker.1 | 2023-07-19T13:44:19.552Z pid=8 tid=qtw INFO: Shutting down
punchclock-app-1       | 13:44:19 worker.1 | 2023-07-19T13:44:19.552Z pid=8 tid=qtw INFO: Terminating quiet threads
punchclock-app-1       | 13:44:19 rails.1  | [7] - Goodbye!
punchclock-app-1       | 13:44:19 rails.1  | [7] - Gracefully shutting down workers...
punchclock-app-1       | 13:44:19 worker.1 | 2023-07-19T13:44:19.553Z pid=8 tid=rtg INFO: Scheduler exiting...
punchclock-app-1       | 13:44:19 rails.1  | Exiting
punchclock-app-1       | 13:44:19 rails.1  | terminated by SIGTERM
punchclock-app-1       | 13:44:20 worker.1 | 2023-07-19T13:44:20.056Z pid=8 tid=qtw INFO: Pausing to allow jobs to finish...
punchclock-app-1       | 13:44:21 worker.1 | 2023-07-19T13:44:21.059Z pid=8 tid=qtw INFO: Bye!
punchclock-app-1       | 13:44:21 worker.1 | exited with code 0
punchclock-app-1 exited with code 0
```
However, when running the project locally, that error doesn't happen.
Following [this answer](https://github.com/rails/rails/issues/44048#issuecomment-1004734401), I added `tty: true` to the `app` container in the `docker-compose.yaml` file.

Now, the project runs perfectly with docker.