### PR TITLE
Order users' contributions by `created_at`

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -4,7 +4,7 @@ class ContributionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @user_contributions = scopped_contributions.approved.order(pr_state: :desc)
+    @user_contributions = scopped_contributions.approved.order(created_at: :desc)
   end
 
   def edit


### PR DESCRIPTION
Users' contributions are now ordered by newest ones first.

The contributions controller specs seemed to be mocking/stubbing the SUT so I changed that while I was in there. 

Closes #487.