### PR TITLE
test: Fix flaky users controller spec

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -50,19 +50,20 @@ describe UsersController do
     before do
       set_2fa
     end
-    
+
     context 'with valid information' do
       it 'redirects to root_path' do
         post :confirm_otp, params: { otp_attempt: user.current_otp }
-        
+
         expect(response).to redirect_to backup_codes_path
       end
     end
-    
+
     context 'with invalid information' do
       it 'renders "two_factor" view' do
         otp = user.current_otp
-        post :confirm_otp, params: { otp_attempt: otp.chars.shuffle.join }
+
+        post :confirm_otp, params: { otp_attempt: suffle_otp(otp) }
 
         expect(response).to redirect_to two_factor_path
       end
@@ -85,7 +86,7 @@ describe UsersController do
     context 'with valid information' do
       it 'deactivate 2FA' do
         post :deactivate_otp, params: { otp_attempt: user.current_otp }
-  
+
         expect(response).to redirect_to root_path
       end
     end

--- a/spec/support/2fa_otp_helper.rb
+++ b/spec/support/2fa_otp_helper.rb
@@ -1,0 +1,9 @@
+def suffle_otp(otp)
+  new_otp = otp.chars.shuffle.join
+
+  if new_otp == otp
+    suffle_otp(new_otp)
+  else
+    new_otp
+  end
+end


### PR DESCRIPTION
Previously, the spec would fail occasionally bacause of its implementation of the method `shuffle`. Due to its nature, it was possible that the code implemented would not change the original string of numbers, resulting in a failing spec.

<img width="984" alt="Captura de Tela 2023-07-26 às 11 12 08" src="https://github.com/Codeminer42/Punchclock/assets/52546576/4bdb87bd-3859-4b65-a163-766bc890bd78">

An example of a likely scenario:
<img width="341" alt="Captura de Tela 2023-07-26 às 12 22 27" src="https://github.com/Codeminer42/Punchclock/assets/52546576/4a1e5510-684c-497f-834b-dcc14d9f21be">

This PR aims to fix this issue, creating a support method that verifies if the shuffled string is, in fact, different from the original one.

