### PR TITLE
Fix calendar disabled day

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,7 @@ Install the docker and docker compose plugin versions:
 ```console
 $ cp config/database.yml.example config/database.yml
 $ docker compose build
-$ docker compose run --rm app bundle install
-$ docker compose run --rm app yarn install --frozen-lockfile
-$ docker compose run --rm app bundle exec rake db:reset
-$ docker compose run --rm app bundle exec rake db:create
+$ docker compose run --rm app bin/setup
 ```
 
 #### Useful commands

--- a/app/javascript/packs/utils/calendar.js
+++ b/app/javascript/packs/utils/calendar.js
@@ -2,53 +2,58 @@ import Immutable from 'immutable';
 import moment from 'moment';
 
 const daysPerWeek = 7;
-const Day = Immutable.Record({day: undefined, inner: undefined, today: false});
-const Week = Immutable.Record({days: Immutable.List()});
-const INCLUSIVITY = '[]' 
+const Day = Immutable.Record({ day: undefined, inner: undefined, today: false });
+const Week = Immutable.Record({ days: Immutable.List() });
+const INCLUSIVITY = '[]'
+const MONDAY = 1;
+const MONTH_31ST = 31;
 
-export function prev(base){
+export function prev(base) {
   return base.clone().subtract(1, 'M');
 }
 
-export function next(base){
+export function next(base) {
   return base.clone().add(1, 'M');
 }
 
-export function week(date, range){
-  return Immutable.Range(0, daysPerWeek).map((i)=> {
+export function week(date, range) {
+  return Immutable.Range(0, daysPerWeek).map((i) => {
     let day = date.clone().add(i, 'd');
     let [from, to] = range;
-    let inner = day.isBetween(from, to, 'day', INCLUSIVITY);
+    // For this to work is considered that 
+    // each month is presented with the 1st day of the month
+    // always in the first line
+    let inner = day.isBetween(from, to, 'day', INCLUSIVITY) || (day.date() === MONTH_31ST && day.weekday() === MONDAY);
     let today = day.isSame(moment(), 'day');
     return new Day({ day: day, inner: inner, today: today });
   });
 }
 
-export function weeks(start, range){
+export function weeks(start, range) {
   const weeksToShow = 5;
-  return Immutable.Range(0, weeksToShow).map((i)=> {
-    return new Week({days: week(start.clone().add(i, 'w'), range)});
+  return Immutable.Range(0, weeksToShow).map((i) => {
+    return new Week({ days: week(start.clone().add(i, 'w'), range) });
   });
 }
 
-export function innerRange(base){
+export function innerRange(base) {
   return [base.clone(),
-          moment.min(base.clone().add(1, 'M').subtract(1, 'd'), current())];
+  moment.min(base.clone().add(1, 'M').subtract(1, 'd'), current())];
 }
 
-export function monthNames(range){
+export function monthNames(range) {
   let [from, to] = range;
 
-  if(from.year() != to.year()) {
+  if (from.year() != to.year()) {
     return [from.format('MMM YYYY'), to.format('MMM YYYY')].join(' / ');
-  } else if(from.month() == to.month()) {
+  } else if (from.month() == to.month()) {
     return from.format('MMMM YYYY');
   }
 
   return [from.format('MMM'), to.format('MMM')].join(' / ') + to.format(' YYYY');
 }
 
-export function startDate(base){
+export function startDate(base) {
   return base.clone().day(0);
 }
 

--- a/test/javascript/packs/utils/calendar.test.js
+++ b/test/javascript/packs/utils/calendar.test.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { compareHours, prev, next, current, innerRange, startDate } from "../../../../app/javascript/packs/utils/calendar";
+import { compareHours, prev, next, current, innerRange, startDate, week } from "../../../../app/javascript/packs/utils/calendar";
 
 const formattedDate = (date) => date.format('YYYY-MM-DD');
 const CURRENT_DATE = '2022-08-15'
@@ -110,6 +110,18 @@ describe("calendar", () => {
       const result = startDate(baseDate)
       const formattedResult = formattedDate(result)
       expect(formattedResult).toBe('2022-06-26')
+    });
+  });
+
+  describe('week', () => {
+    it('returns the day as inner when the 31st day of the month before is Monday', () => {
+      const baseDate = moment('2023-08-1', 'YYYY-MM-DD').utc()
+      const range = innerRange(baseDate)
+
+      const processedWeekMonday = week(baseDate, range).get(1)
+
+      expect(processedWeekMonday.day.month()).toBe(7)
+      expect(processedWeekMonday.inner).toBe(true)
     });
   });
 });


### PR DESCRIPTION
When the month has 31 days and it starts on Saturday, its 31st day doesn't appears in the current month

![image](https://github.com/Codeminer42/Punchclock/assets/79609888/51fcdaea-0b4c-4f97-a42f-d7218ea2546a)

And its 31st day appears disabled in the next month because it is not the current month.

![image](https://github.com/Codeminer42/Punchclock/assets/79609888/d47e3ffd-c2d6-4eac-a48c-7a4a993aca50)

This PR fix this edge case, activating the day in the next month.

![image](https://github.com/Codeminer42/Punchclock/assets/79609888/449323ff-851c-4b57-888f-e4799b83dbf5)
