### PR TITLE
test: Name skills in `users_helper_spec` to avoid encoding inconsistencies

### DIFF
--- a/spec/helpers/active_admin/users_helper_spec.rb
+++ b/spec/helpers/active_admin/users_helper_spec.rb
@@ -8,9 +8,12 @@ module ActiveAdmin
       subject { helper.skills_tags(user) }
 
       let(:user) { create(:user) }
+      let!(:expert_skill) { create(:skill, title: "Ruby") }
+      let!(:capable_skill) { create(:skill, title: "Javascript") }
+
       let!(:user_skills) do
-        [create(:user_skill, user:, experience_level: :expert),
-         create(:user_skill, user:, experience_level: :capable)]
+        [create(:user_skill, user:, experience_level: :expert, skill: expert_skill),
+         create(:user_skill, user:, experience_level: :capable, skill: capable_skill)]
       end
 
       it "returns the tags for all user's skills" do


### PR DESCRIPTION
The factory for Skills can occasionally return a title containing apostrophes in it, which would cause the spec validating the content_tag to fail. This PR establishes a non-volatile name for skill titles.
```
1) ActiveAdmin::UsersHelper#skills_tags returns the tags for all user's skills
     Failure/Error: expect(subject).to eq("<span class=\"status_tag yes\">#{user_skills[0].skill.title}</span> <span class=\"status_tag no\">#{user_skills[1].skill.title}</span>")

       expected: "<span class=\"status_tag yes\">NetLogo</span> <span class=\"status_tag no\">App Inventor for Android's visual block language</span>"
            got: "<span class=\"status_tag yes\">NetLogo</span> <span class=\"status_tag no\">App Inventor for Android&#39;s visual block language</span>"

       (compared using ==)
```