### PR TITLE
Shows total worked hours

### DIFF
--- a/app/javascript/packs/components/Punches.js
+++ b/app/javascript/packs/components/Punches.js
@@ -1,12 +1,21 @@
-import React from 'react';
-import Punch from './Punch';
+import React from "react";
+import Punch from "./Punch";
+import { isEmpty } from "lodash";
 
 const Punches = ({ sheet }) => {
+  if (isEmpty(sheet)) return null;
+
+  const totalWorkedHours = sheet.reduce(
+    (total, current) => (total += current.delta),
+    0
+  );
+
   return (
     <ul className="punches">
-      { sheet.map((punch, i) =>
-       <Punch key={i} punch={punch} />
-      )}
+      {sheet.map((punch, i) => (
+        <Punch key={i} punch={punch} />
+      ))}
+      <li>Total: {totalWorkedHours}h</li>
     </ul>
   );
 };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-cli": "^3.3.3"
   },
   "jest": {
+    "testEnvironment": "jsdom",
     "modulePathIgnorePatterns": [
       "config/webpack/test.js"
     ]

--- a/test/javascript/packs/components/Punches.test.js
+++ b/test/javascript/packs/components/Punches.test.js
@@ -1,0 +1,45 @@
+import React from "react";
+import Punches from "../../../../app/javascript/packs/components/Punches";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+describe("when sheet is not empty", () => {
+  const sheet = [
+    {
+      from: "2023-07-31T05:00:00.000-03:00",
+      to: "2023-07-31T09:00:00.000-03:00",
+      project_id: 3,
+      delta: 4,
+    },
+    {
+      from: "2023-07-31T10:00:00.000-03:00",
+      to: "2023-07-31T13:00:00.000-03:00",
+      project_id: 3,
+      delta: 3,
+    },
+  ];
+
+  it("renders list with worked intervals", () => {
+    render(<Punches sheet={sheet} />);
+
+    expect(screen.queryByRole("list")).toBeInTheDocument();
+    expect(screen.queryByText("05:00 - 09:00")).toBeInTheDocument();
+    expect(screen.queryByText("10:00 - 13:00")).toBeInTheDocument();
+  });
+
+  it("renders total worked hours", () => {
+    render(<Punches sheet={sheet} />);
+
+    expect(screen.queryByText("Total: 7h")).toBeInTheDocument();
+  });
+});
+
+describe("when sheet is empty", () => {
+  const sheet = [];
+
+  it("doesn't renders list", () => {
+    const { container } = render(<Punches sheet={sheet} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Simple feature to show the total worked hours per day on multiple punch dashboard to prevent wrong inputs. 

Before:
![image](https://github.com/Codeminer42/Punchclock/assets/79609888/92af3bc1-2aa0-498d-b6a9-9c5ac3f8d38b)

After: 
![image](https://github.com/Codeminer42/Punchclock/assets/79609888/a4f95018-d975-4f15-9c8e-7ff7dc9f752a)


