### PR TITLE
feat: Include arm64 platform in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.5-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.14.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.5-x86_64-linux)
@@ -583,6 +585,8 @@ GEM
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.30-aarch64-linux)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.30-arm64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.30-x86_64-darwin)
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.30-x86_64-linux)
@@ -626,6 +630,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin
   ruby
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
Fixes:
`Tailwindcss::Commands::ExecutableNotFoundException: Cannot find the tailwindcss executable for arm64-darwin in /Users/thiago/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/tailwindcss-rails-2.0.29/exe
`

and similar errors in arm64-powered machines.


For the security test to pass, https://github.com/Codeminer42/Punchclock/pull/529 needs to be merged.