### PR TITLE
refactor: Replace unsupported optional chaining in navBar.js

### DIFF
--- a/app/assets/javascripts/new_admin/navbar.js
+++ b/app/assets/javascripts/new_admin/navbar.js
@@ -51,7 +51,10 @@ tabButtons.forEach((buttonElement) => {
     setActiveButton(buttonElement)
   });
 });
-tabButtons[0]?.click();
+
+if (tabButtons && tabButtons[0] && typeof tabButtons[0].click === 'function') {
+   tabButtons[0].click();
+}
 
 window.addEventListener("load", () => {
   const anchor = window.location.hash


### PR DESCRIPTION
Our current node version doesn't support the [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) syntax. Thus, we need to manually check the element presence.