### PR TITLE
fix: Add links of contributions to e-mail description

### DIFF
--- a/app/jobs/alert_fill_contribution_description_job.rb
+++ b/app/jobs/alert_fill_contribution_description_job.rb
@@ -3,10 +3,14 @@ class AlertFillContributionDescriptionJob < ApplicationJob
 
   def perform(user_id)
     user = User.find(user_id)
-    contributions = user.contributions.received 
+    contributions = user.contributions.received.without_description
 
     unless contributions.empty?
-      NotificationMailer.notify_fill_contribution_description(user, contributions.length).deliver_later
+      NotificationMailer.notify_fill_contribution_description(
+        user: user,
+        contributions_total: contributions.length,
+        contributions_links: contributions.pluck(:id, :link)
+      ).deliver_later
     end
   end
 end

--- a/app/jobs/alert_fill_contribution_description_job.rb
+++ b/app/jobs/alert_fill_contribution_description_job.rb
@@ -9,7 +9,7 @@ class AlertFillContributionDescriptionJob < ApplicationJob
       NotificationMailer.notify_fill_contribution_description(
         user: user,
         contributions_total: contributions.length,
-        contributions_links: contributions.pluck(:id, :link)
+        contributions_links: contributions.map { [_1.id, _1.link] }
       ).deliver_later
     end
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -59,9 +59,10 @@ class NotificationMailer < ActionMailer::Base
     mail(to: newsletter_email, subject: 'Punchlock - Contribuições aprovadas')
   end
 
-  def notify_fill_contribution_description(user, contributions_total)
+  def notify_fill_contribution_description(user:, contributions_total:, contributions_links:)
     @user = user
-    @contributions_total = contributions_total 
+    @contributions_total = contributions_total
+    @contributions_links = contributions_links
     mail(to: @user.email, subject: t('notification_mailer.subject.notify_fill_contribution_description_html'))
   end
 end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -64,6 +64,7 @@ class Contribution < ApplicationRecord
   scope :valid_pull_requests, -> { where.not(state: :refused) }
   scope :without_pr_state, ->(state) { where.not(pr_state: state) }
   scope :tracking, -> { where(tracking: true) }
+  scope :without_description, -> { where(description: nil) }
 
   private
 

--- a/app/views/notification_mailer/notify_fill_contribution_description.html.erb
+++ b/app/views/notification_mailer/notify_fill_contribution_description.html.erb
@@ -14,8 +14,4 @@
   <% end %>
 </ul>
 
-<p>
-  <%= @contributions_page %>
-</p>
-
 Abs

--- a/app/views/notification_mailer/notify_fill_contribution_description.html.erb
+++ b/app/views/notification_mailer/notify_fill_contribution_description.html.erb
@@ -1,7 +1,21 @@
-<%= 
-  t('notification_mailer.notify_fill_contribution_description_html',
-    host: ENV['HOST'],
-    contributions_total: @contributions_total,
-    contributions_link: link_to("Acessar PRs", contributions_url)
-   ) 
- %>
+<p>
+  Olá,
+</p>
+
+<p>
+  Você possui <%= @contributions_total %> contribuições aguardando descrição da PR:
+</p>
+
+<ul>
+  <% @contributions_links.each do |id, link| %>
+    <li>
+      <%= link_to link, edit_contribution_url(id) %>
+    </li>
+  <% end %>
+</ul>
+
+<p>
+  <%= @contributions_page %>
+</p>
+
+Abs

--- a/app/views/notification_mailer/notify_fill_contribution_description.html.erb
+++ b/app/views/notification_mailer/notify_fill_contribution_description.html.erb
@@ -1,9 +1,9 @@
 <p>
-  Olá,
+  <%= t '.info', user: @user %>
 </p>
 
 <p>
-  Você possui <%= @contributions_total %> contribuições aguardando descrição da PR:
+  Você possui <%= t '.contributions', count: @contributions_total %> aguardando descrição da PR:
 </p>
 
 <ul>

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -58,17 +58,11 @@ pt-BR:
         E avisem hora extra para <strong>"rh@codeminer42.com"</strong>
       </p>
       Abs
-    notify_fill_contribution_description_html: |
-      <p>
-        Olá,
-      </p>
-      <p>
-        Você possui %{contributions_total} contribuições aguardando descrição da PR.
-      </p>
-      <p>
-        %{contributions_page}
-      </p>
-      Abs
+    notify_fill_contribution_description:
+      info: "Olá, %{user}"
+      contributions:
+        one: "%{count} contribuição"
+        other: "%{count} contribuições"
     notify_admin_extra_hour:
       info: "%{user} registrou hora extra:"
       days:

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -28,7 +28,7 @@ pt-BR:
     form:
       submit: 'Salvar Revisão'
   notification_mailer:
-    subject: 
+    subject:
       notify_fill_contribution_description_html: 'Punchlock - Contribuições Aguardando Descrição'
     body_html: |
       <p>
@@ -66,7 +66,7 @@ pt-BR:
         Você possui %{contributions_total} contribuições aguardando descrição da PR.
       </p>
       <p>
-        %{contributions_link}
+        %{contributions_page}
       </p>
       Abs
     notify_admin_extra_hour:

--- a/spec/jobs/alert_fill_contribution_description_job_spec.rb
+++ b/spec/jobs/alert_fill_contribution_description_job_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe AlertFillContributionDescriptionJob, type: :job do
       let(:contributions) { create_list(:contribution, 3, user: user) }
       # TODO
       it "sends a notification email when user has received contributions" do
-        expect(NotificationMailer).to receive(:notify_fill_contribution_description).with(user, contributions.length).and_return(double(deliver_later: true))
+        expect(NotificationMailer).to receive(:notify_fill_contribution_description)
+          .with(user:, contributions_total: contributions.length, contributions_links: contributions.pluck(:id, :link))
+          .and_return(double(deliver_later: true))
 
         perform_enqueued_jobs do
           described_class.perform_later(user.id)

--- a/spec/jobs/alert_fill_contribution_description_job_spec.rb
+++ b/spec/jobs/alert_fill_contribution_description_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AlertFillContributionDescriptionJob, type: :job do
 
     context "when user has received contributions" do
       let(:contributions) { create_list(:contribution, 3, user: user) }
-      # TODO
+
       it "sends a notification email when user has received contributions" do
         expect(NotificationMailer).to receive(:notify_fill_contribution_description)
           .with(user:, contributions_total: contributions.length, contributions_links: contributions.pluck(:id, :link))

--- a/spec/jobs/alert_fill_contribution_description_job_spec.rb
+++ b/spec/jobs/alert_fill_contribution_description_job_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe AlertFillContributionDescriptionJob, type: :job do
 
     context "when user has received contributions" do
       let(:contributions) { create_list(:contribution, 3, user: user) }
+      # TODO
       it "sends a notification email when user has received contributions" do
         expect(NotificationMailer).to receive(:notify_fill_contribution_description).with(user, contributions.length).and_return(double(deliver_later: true))
-        
+
         perform_enqueued_jobs do
           described_class.perform_later(user.id)
         end
@@ -22,7 +23,7 @@ RSpec.describe AlertFillContributionDescriptionJob, type: :job do
       let(:contributions) { create_list(:contribution, 3, :approved, user: user) }
       it "does not send a notification email when user has no received contributions" do
         expect(NotificationMailer).not_to receive(:notify_fill_contribution_description)
-        
+
         perform_enqueued_jobs do
           described_class.perform_later(user.id)
         end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -250,11 +250,17 @@ describe NotificationMailer do
       end
     end
 
-    # TODO
     context 'when notify user to fill contribution description' do
       let(:user) { create(:user) }
       let!(:contributions) { FactoryBot.create_list(:contribution, 5, user: user) }
-      let(:mail) { NotificationMailer.notify_fill_contribution_description(user, contributions.length) }
+      let(:mail) do
+        NotificationMailer
+          .notify_fill_contribution_description(
+            user:,
+            contributions_total: contributions.length,
+            contributions_links: contributions.pluck(:id, :link)
+          )
+      end
 
       it 'renders the subject' do
         expect(mail.subject).to eq('Punchlock - Contribuições Aguardando Descrição')
@@ -272,8 +278,10 @@ describe NotificationMailer do
         expect(mail.body.encoded).to match('5')
       end
 
-      it 'renders the contribution link' do
-        expect(mail.body.encoded).to have_link('Acessar PRs', href: contributions_url)
+      it 'renders the list of contributions links' do
+        contributions.each do |contribution|
+          expect(mail.body.encoded).to have_selector('li', text: contribution.link)
+        end
       end
     end
   end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -258,7 +258,7 @@ describe NotificationMailer do
           .notify_fill_contribution_description(
             user:,
             contributions_total: contributions.length,
-            contributions_links: contributions.pluck(:id, :link)
+            contributions_links: contributions.map { [_1.id, _1.link] }
           )
       end
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -250,6 +250,7 @@ describe NotificationMailer do
       end
     end
 
+    # TODO
     context 'when notify user to fill contribution description' do
       let(:user) { create(:user) }
       let!(:contributions) { FactoryBot.create_list(:contribution, 5, user: user) }

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -118,6 +118,26 @@ RSpec.describe Contribution, type: :model do
     end
   end
 
+  describe '.without_description' do
+    let!(:contributions) { create_list :contribution, 2, description: }
+
+    context 'when contribution has no description' do
+      let(:description) { nil }
+
+      it 'returns the contributions' do
+        expect(described_class.without_description).to match_array(contributions)
+      end
+    end
+
+    context 'when contribution have description' do
+      let(:description) { "Described" }
+
+      it 'returns empty relation' do
+        expect(described_class.without_description).to be_empty
+      end
+    end
+  end
+
   describe '.without_pr_state' do
     it "returns contributions without the received pr state" do
       open_pr = create :contribution, pr_state: :open


### PR DESCRIPTION
This PR changed the e-mail referring to PRs without description to include the links to Punchclock, instead of not specifying any of the required PRs.

![image](https://github.com/Codeminer42/Punchclock/assets/50644753/9b63e3c7-5fbd-4e6f-89d5-12333d46cb75)

Fixes #535