### PR TITLE
improvement: add cursor pointer for devise pages

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -15,7 +15,7 @@
     </div>
 
   <%= f.button :submit, t("resend_instructions"),
-  class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 mb-4" %>
+  class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 mb-4 cursor-pointer" %>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -25,7 +25,7 @@
 
   <div>
     <%= f.submit t("form.button.change_my_password"),
-        class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 mb-4" %>
+        class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 mb-4 cursor-pointer" %>
   </div>
 <% end %>
 <%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -16,7 +16,7 @@
       label_html: { class: "block mb-2 text-base text-grey-400" } %>
 
     <%= f.button :submit, t("send_reset_instructions"),
-        class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 mb-4" %>
+        class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 mb-4 cursor-pointer" %>
 
 <% end %>
 <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -24,7 +24,7 @@
   <div class="w-full flex flex-col items-start justify-between space-y-4 mt-8 md:flex-row md:items-center md:space-y-0">
     <%= f.input :remember_me,
           as: :boolean,
-          input_html: { class: "appearance-none w-5 h-5 mr-2 bg-grey-50 border-0 rounded-md focus:ring-0 text-grey-400" },
+          input_html: { class: "appearance-none w-5 h-5 mr-2 bg-grey-50 border-0 rounded-md focus:ring-0 text-grey-400 cursor-pointer" },
           label_html: { class: "text-base text-grey-400 font-medium" } if devise_mapping.rememberable? %>
 
     <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
@@ -32,5 +32,5 @@
     <% end %>
   </div>
 
-  <%= f.button :submit, "Login", class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110" %>
+  <%= f.button :submit, "Login", class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 cursor-pointer" %>
 <% end %>

--- a/app/views/devise/sessions/two_factor.html.erb
+++ b/app/views/devise/sessions/two_factor.html.erb
@@ -16,7 +16,7 @@
                     label_html: { class: "block mb-2 text-base text-grey-400" } %>
   </div>
 
-  <%= f.button :submit, t("form.button.verify"), class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110" %>
+  <%= f.button :submit, t("form.button.verify"), class: "w-full h-10 mt-8 px-4 rounded bg-red text-white transition-all hover:brightness-110 cursor-pointer" %>
 
   <div class="w-full flex mt-8">
     <%= link_to t("form.links.return_to_sign_in"), :back, class: 'text-sm text-blue' %>


### PR DESCRIPTION
### Improves Sign In, 2FA, Resend reset password instructions, change password and password reset cursor indicator

Attending to the issue #452 i added a tailwind css property `cursor-pointer` on clickable buttons and checkboxes from devise sessions, passwords and confirmations pages.

The original issue was describing Sign In and 2FA only but while i was navigating through the views i thought that it would be a good idea to adjust the same problem on other pages too.

Sign In page now:

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/2f32bdf4-b3c0-42a0-9bec-832952a4ad5f)

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/f10847ab-8cc1-4150-aebe-981ef75f0e6d)

2FA page now:

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/3d21e9ba-d19e-420c-92ce-a886d9403e40)

Resend password confirmation page before:

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/45131484-ab6b-4925-b5ee-11d674174ad7)

Now: 

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/11daa4f7-377c-44b8-a093-3c40772c0a4e)

Change password page before:

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/6068622b-60e2-492a-b4cc-dd37bb8686e7)

Now: 

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/781c0fa3-3541-469e-b664-14af452e1ae0)

Resend reset password instructions page before:

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/9ced2a4e-3a08-4eca-b4d8-3eff209ae926)

Now: 

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/e5133bb7-e4b0-4b19-ae01-386ff1932549)
