### PR TITLE
improvement: add highlight for forecasts table 

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -137,3 +137,39 @@ body.logged_in .flash {
 .member_link_refuse:hover {
   cursor: pointer;
 }
+
+.forecast-table {
+  display: flex;
+  overflow: hidden;
+}
+
+.forecast-table-cell {
+  position: relative;
+}
+
+.forecast-table-cell:hover::before {
+  content: "";
+  background-color: #5EA3D3;
+  position: absolute;
+  height: 170%;
+  top: 0;
+  left: -5000px;
+  width: 10000px;
+  opacity: 0.3;
+}
+
+.forecast-table-cell:hover::after {
+  content: "";
+  background-color: #5EA3D3;
+  position: absolute;
+  height: 10000px;
+  top: -5000px;
+  left: 0;
+  width: 100%;
+  opacity: 0.2;
+}
+
+.forecast-table-cell::before,
+.forecast-table-cell::after {
+  pointer-events: none;
+}

--- a/app/views/admin/revenue_forecast/_forecasts_table.html.arb
+++ b/app/views/admin/revenue_forecast/_forecasts_table.html.arb
@@ -1,21 +1,21 @@
-columns do
+columns class: "forecast-table" do
   column do
-    para(I18n.t('projects.title'), style: 'font-weight: bold')
+    para(I18n.t('projects.title'), style: 'font-weight: bold', class: "forecast-table-cell")
 
     forecast.projects.each do |project|
-      para(project.name, style: 'font-weight: bold')
+      para(project.name, style: 'font-weight: bold', class: "forecast-table-cell")
     end
   end
 
   forecast.months do |month_name, forecasts, total|
     column do
-      para(month_name, style: 'font-weight: bold')
+      para(month_name, style: 'font-weight: bold', class: "forecast-table-cell")
 
       forecasts.each do |forecast|
-        para forecast
+        para forecast, class: "forecast-table-cell"
       end
 
-      span(total, style: 'color: blue')
+      span(total, style: 'color: blue', class: "forecast-table-cell")
     end
   end
 end


### PR DESCRIPTION
## Add column and row highlighting when hovering over a cell on forecasts table cells

### Problem

As described on issue #542, the table on Revenue Forecasts page can become harder to read as the number of row increases, due to how much info's available at it. It would be interesting if we had a highlight on current cell's column and row when hovering over them.

### Solution

To make the highlight work i used a technique that consists of creating two big pseudo-elements with the desired background color every time we hover on that cell with the mouse, being that one's for the column highlight and the other's for the row. To stop those elements to overflow the forecast's table height and width `overflow: hidden` property does the trick . For more details over that trick (credits for Talysson Oliveira) see [this link](https://css-tricks.com/simple-css-row-column-highlighting/).

Due to css hover characteristics and how forecasts table works, there's another trick to properly render those pseudo-elements (credits for Samuel Flores): it consists of adding the property `pointer-events: none` to our cells, forcing them to ignore any mouse event and, although the cells ignore them, our pseudo-elements won't, and are going to be rendered without any overlap or bug.

### Result

![demo-542](https://github.com/Codeminer42/Punchclock/assets/50427117/703432cc-8561-47e0-89a2-3b814ea0d43b)
