### PR TITLE
Remove level attribute from user

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -10,7 +10,6 @@ ActiveAdmin.register_page "Dashboard" do
 
         users_collection = User.active.includes(:office).order(:name).map do |user|
           user_label = "#{user.name.titleize} - #{user.email} - "
-  #        user_label += "#{user.level.humanize} - " if user.engineer?
           user_label += "#{user.office} - #{user.current_allocation.presence || 'Não Alocado'}"
 
           [user_label, user.id]

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -10,7 +10,7 @@ ActiveAdmin.register_page "Dashboard" do
 
         users_collection = User.active.includes(:office).order(:name).map do |user|
           user_label = "#{user.name.titleize} - #{user.email} - "
-          user_label += "#{user.level.humanize} - " if user.engineer?
+  #        user_label += "#{user.level.humanize} - " if user.engineer?
           user_label += "#{user.office} - #{user.current_allocation.presence || 'Não Alocado'}"
 
           [user_label, user.id]
@@ -44,17 +44,6 @@ ActiveAdmin.register_page "Dashboard" do
     end
 
     columns do
-      if AbilityAdmin.new(current_user).can?(:read, User)
-        column do
-          panel t(I18n.t('average_score'), scope: 'active_admin'), class: 'average-score' do
-            table_for User.level.values do
-              column(User.human_attribute_name(:level)) { |level| User.human_attribute_name(level) }
-              column(I18n.t('users_average')) { |level| User.with_level(level).overall_score_average }
-            end
-          end
-        end
-      end
-
       if AbilityAdmin.new(current_user).can? :read, Contribution
         column do
           panel t(I18n.t('offices_leaderboard'), scope: 'active_admin') do

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register User do
 
   menu parent: User.model_name.human(count: 2), priority: 1
 
-  permit_params :name, :email, :github, :backend_level, :frontend_level, :level, :contract_type, :contract_company_country, :mentor_id,
+  permit_params :name, :email, :github, :backend_level, :frontend_level, :contract_type, :contract_company_country, :mentor_id,
                 :city_id, :active, :allow_overtime, :office_id, :occupation, :started_at,
                 :observation, :specialty, :otp_required_for_login, roles: []
 
@@ -99,7 +99,6 @@ ActiveAdmin.register User do
           row :backend_level, &:backend_level_text
           row :frontend_level, &:frontend_level_text
           row :specialty, &:specialty_text
-          row :level, &:level_text
           row :contract_type, &:contract_type_text
           row :contract_company_country, &:contract_company_country_text
 
@@ -270,7 +269,6 @@ ActiveAdmin.register User do
       f.input :backend_level, as: :select, collection: User.backend_level.options
       f.input :frontend_level, as: :select, collection: User.frontend_level.options
       f.input :specialty, as: :select, collection: User.specialty.values.map { |specialty| [specialty.text.humanize, specialty] }
-      f.input :level, as: :select, collection: User.level.values.map { |level| [level.text.titleize,level] }
       f.input :contract_type, as: :select, collection: User.contract_type.values.map { |contract_type| [contract_type.text.humanize, contract_type] }
       f.input :contract_company_country, as: :select, collection: User.contract_company_country.values.map { |company_country| [company_country.text.humanize, company_country] }
       f.input :allow_overtime

--- a/app/controllers/new_admin/users_controller.rb
+++ b/app/controllers/new_admin/users_controller.rb
@@ -67,7 +67,7 @@ module NewAdmin
     end
 
     def user_params
-      params.require(:user).permit(:name, :email, :github, :backend_level, :frontend_level, :level, :contract_type,
+      params.require(:user).permit(:name, :email, :github, :backend_level, :frontend_level, :contract_type,
                                    :contract_company_country, :mentor_id, :city_id, :active, :allow_overtime, :office_id, :occupation, :started_at, :observation, :specialty, :otp_required_for_login, roles: [])
     end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -19,10 +19,6 @@ class UserDecorator < Draper::Decorator
     "Backend #{model.backend_level.humanize}"
   end
 
-  def level
-    model.level.try(:humanize) || 'N/A'
-  end
-
   def specialty
     model.specialty.try(:humanize) || 'N/A'
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,11 +19,6 @@ class User < ApplicationRecord
       i18n_scope: 'enumerize.user.level'
   end
 
-  # enumerize :level, in: {
-  #   trainee: 7, intern: 0, junior: 1, junior_plus: 2, mid: 3, mid_plus: 4, senior: 5, senior_plus: 6
-  #   },  scope: :shallow,
-  #       predicates: true
-
   enumerize :occupation, in: {
     administrative: 0, engineer: 1
     },  scope: :shallow,
@@ -83,7 +78,6 @@ class User < ApplicationRecord
   scope :allocated, -> { engineer.active.where(id: Allocation.ongoing.select(:user_id)) }
   scope :by_skills_in,   ->(*skill_ids) { UsersBySkillsQuery.where(ids: skill_ids) }
   scope :not_in_experience, -> { where arel_table[:created_at].lt(EXPERIENCE_PERIOD.ago) }
-  #scope :with_level,       -> value { where(level: value) }
   scope :by_roles_in, -> roles {
     roles_values = self.roles.find_values(*roles).map(&:value)
     where("users.roles && ARRAY[?]::int[]", roles_values)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,10 @@ class User < ApplicationRecord
       i18n_scope: 'enumerize.user.level'
   end
 
-  enumerize :level, in: {
-    trainee: 7, intern: 0, junior: 1, junior_plus: 2, mid: 3, mid_plus: 4, senior: 5, senior_plus: 6
-    },  scope: :shallow,
-        predicates: true
+  # enumerize :level, in: {
+  #   trainee: 7, intern: 0, junior: 1, junior_plus: 2, mid: 3, mid_plus: 4, senior: 5, senior_plus: 6
+  #   },  scope: :shallow,
+  #       predicates: true
 
   enumerize :occupation, in: {
     administrative: 0, engineer: 1
@@ -73,7 +73,7 @@ class User < ApplicationRecord
   validates :city, presence: true
   validates :name, :occupation, presence: true
   validates :email, uniqueness: true, presence: true
-  validates :level, :specialty, presence: true, if: :engineer?
+  validates :specialty, presence: true, if: :engineer?
   validates :github, uniqueness: true, if: :engineer?
 
   scope :active,         -> { where(active: true) }
@@ -83,7 +83,7 @@ class User < ApplicationRecord
   scope :allocated, -> { engineer.active.where(id: Allocation.ongoing.select(:user_id)) }
   scope :by_skills_in,   ->(*skill_ids) { UsersBySkillsQuery.where(ids: skill_ids) }
   scope :not_in_experience, -> { where arel_table[:created_at].lt(EXPERIENCE_PERIOD.ago) }
-  scope :with_level,       -> value { where(level: value) }
+  #scope :with_level,       -> value { where(level: value) }
   scope :by_roles_in, -> roles {
     roles_values = self.roles.find_values(*roles).map(&:value)
     where("users.roles && ARRAY[?]::int[]", roles_values)

--- a/app/spreadsheets/users_spreadsheet.rb
+++ b/app/spreadsheets/users_spreadsheet.rb
@@ -5,7 +5,6 @@ class UsersSpreadsheet < DefaultSpreadsheet
     [
       user.name,
       user.email,
-      user.level_text,
       user.office&.city,
       user.roles_text,
       user.specialty_text,
@@ -20,7 +19,6 @@ class UsersSpreadsheet < DefaultSpreadsheet
     %w[
       name
       email
-      level
       office
       roles
       specialty

--- a/app/views/evaluations/index.html.erb
+++ b/app/views/evaluations/index.html.erb
@@ -11,7 +11,6 @@
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Level</th>
                 <th>Office</th>
                 <th>Last Performance Evaluation</th>
                 <th>Last Performance Evaluation Score</th>
@@ -24,7 +23,6 @@
               <% @users.each do |user| %>
                 <tr>
                   <td><%= user.name %></td>
-                  <td><%= user.level %></td>
                   <td><%= user.office %></td>
                   <td>
                     <% if user.last_performance_evaluation %>

--- a/app/views/new_admin/allocation_charts/_allocations.html.erb
+++ b/app/views/new_admin/allocation_charts/_allocations.html.erb
@@ -4,7 +4,6 @@
       <th class="px-4 py-3"><%= t 'name' %></th>
       <th class="px-4 py-3"><%= t 'client' %></th>
       <th class="px-4 py-3"><%= t 'allocated_until' %></th>
-      <th class="px-4 py-3"><%= t 'level' %></th>
       <th class="px-4 py-3"><%= t 'specialty' %></th>
       <th class="px-4 py-3"><%= t 'english_evaluation' %></th>
       <th class="px-4 py-3"><%= t 'skills' %></th>
@@ -45,13 +44,6 @@
               </p>
             </div>
           <% end %>
-        </td>
-        <td class="px-4 py-3">
-          <div class="flex items-center text-sm">
-            <p class="text-sm text-gray-600 dark:text-gray-400">
-              <%= allocation.user.level %>
-            </p>
-          </div>
         </td>
         <td class="px-4 py-3">
           <div class="flex items-center text-sm">

--- a/app/views/new_admin/users/_details.html.erb
+++ b/app/views/new_admin/users/_details.html.erb
@@ -191,20 +191,6 @@
         <tr class="text-gray-700 dark:text-gray-300">
           <th class="w-1/12">
             <div class="ml-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase">
-              <%= User.human_attribute_name('level') %>
-            </div>
-          </th>
-          <td class="px-4 py-3">
-            <div class="flex items-center text-sm">
-              <p class="text-sm text-gray-600 dark:text-gray-400 font-semibold">
-                <%= user.level %>
-              </p>
-            </div>
-          </td>
-        </tr>
-        <tr class="text-gray-700 dark:text-gray-300">
-          <th class="w-1/12">
-            <div class="ml-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase">
               <%= User.human_attribute_name('contract_type') %>
             </div>
           </th>

--- a/app/views/new_admin/users/_form.html.erb
+++ b/app/views/new_admin/users/_form.html.erb
@@ -54,12 +54,6 @@
       </div>
     </div>
 
-
-    <div class="mb-4">
-      <label for="level" class="block text-sm font-medium text-gray-700 dark:text-gray-400"><%= t('level', scope: %i[activerecord attributes user]) %></label>
-      <%= form.select :level, User.level.values.map { |level| [level.text.titleize, level.value] }, {}, class: 'block w-full mt-1 text-sm rounded-md dark:text-gray-300 dark:border-gray-600 dark:bg-gray-700 form-select focus:border-purple-400 focus:outline-none focus:shadow-outline-purple dark:focus:shadow-outline-gray' %>
-    </div>
-
     <div class="mb-4">
       <label for="contract_type" class="block text-sm font-medium text-gray-700 dark:text-gray-400"><%= t('contract_type', scope: %i[activerecord attributes user]) %></label>
       <%= form.select :contract_type, User.contract_type.values.map { |contract_type| [contract_type.text.humanize, contract_type.value] }, {}, class: 'block w-full mt-1 text-sm rounded-md dark:text-gray-300 dark:border-gray-600 dark:bg-gray-700 form-select focus:border-purple-400 focus:outline-none focus:shadow-outline-purple dark:focus:shadow-outline-gray' %>

--- a/db/migrate/20231005131111_remove_level_from_users.rb
+++ b/db/migrate/20231005131111_remove_level_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveLevelFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :level, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_175727) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_05_131111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -246,7 +246,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_175727) do
     t.datetime "confirmation_sent_at", precision: nil
     t.boolean "active", default: true
     t.integer "mentor_id"
-    t.integer "level"
     t.boolean "allow_overtime", default: false
     t.integer "office_id"
     t.integer "occupation"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,6 @@ def create_user(number:)
     user.occupation = :engineer
     user.password = 'password'
     user.office = Office.all.sample
-    user.level = User.level.values.sample
     user.specialty = User.specialty.values.sample
     user.github = "codeminer42.user.teste#{number}"
     user.allow_overtime = true

--- a/spec/controllers/new_admin/allocation_charts_controller_spec.rb
+++ b/spec/controllers/new_admin/allocation_charts_controller_spec.rb
@@ -27,7 +27,6 @@ describe NewAdmin::AllocationChartsController do
             get :index
 
             expect(page).to have_content(user.name)
-                        .and have_content(/#{user.level}/i)
                         .and have_content(/#{user.specialty}/i)
           end
         end

--- a/spec/controllers/new_admin/allocation_charts_controller_spec.rb
+++ b/spec/controllers/new_admin/allocation_charts_controller_spec.rb
@@ -51,7 +51,6 @@ describe NewAdmin::AllocationChartsController do
 
             expect(page).to have_content(allocation.project_name)
                         .and have_content(user.name)
-                        .and have_content(/#{user.level}/i)
                         .and have_content(/#{user.specialty}/i)
                         .and have_content(allocation.end_at.strftime('%d/%m/%Y'))
           end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -79,24 +79,6 @@ RSpec.describe UserDecorator do
     end
   end
 
-  describe '#level' do
-    context 'when level is set' do
-      subject(:user) { build_stubbed(:user, level: 'trainee').decorate }
-
-      it 'returns user level' do
-        expect(subject.level).to eq('Trainee')
-      end
-    end
-
-    context 'when level is nil' do
-      subject(:user) { build_stubbed(:user, level: nil).decorate }
-
-      it 'returns N/A' do
-        expect(subject.level).to eq('N/A')
-      end
-    end
-  end
-
   describe '#english_level' do
     subject(:user) { build_stubbed(:user).decorate }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -61,38 +61,6 @@ FactoryBot.define do
       end
     end
 
-    trait :level_trainee do
-      level { :trainee }
-    end
-
-    trait :level_intern do
-      level { :intern }
-    end
-
-    trait :level_junior do
-      level { :junior }
-    end
-
-    trait :level_junior_plus do
-      level { :junior_plus }
-    end
-
-    trait :level_mid do
-      level { :mid }
-    end
-
-    trait :level_mid_plus do
-      level { :mid_plus }
-    end
-
-    trait :level_senior do
-      level { :senior }
-    end
-
-    trait :level_senior_plus do
-      level { :senior_plus }
-    end
-
     trait :with_started_at do
       started_at { Date.today }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     occupation               { 'engineer' }
     backend_level            { User.backend_level.values.sample }
     frontend_level           { User.frontend_level.values.sample }
-    level                    { 'junior' }
     specialty                { 'backend' }
     github                   { Faker::Internet.unique.username }
     contract_type            { 'employee' }

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -9,23 +9,6 @@ describe 'Dashboard', type: :feature do
 
   let(:open_source_manager_user)   { create(:user, :open_source_manager) }
 
-  before do
-    create(:user, :with_overall_score, :level_intern, score: 8)
-    create(:user, :with_overall_score, :level_intern, score: 3)
-    create(:user, :with_overall_score, :level_junior, score: 7)
-    create(:user, :with_overall_score, :level_junior, score: 9)
-    create(:user, :with_overall_score, :level_junior_plus, score: 1)
-    create(:user, :with_overall_score, :level_junior_plus, score: 5)
-    create(:user, :with_overall_score, :level_mid, score: 8)
-    create(:user, :with_overall_score, :level_mid, score: 6)
-    create(:user, :with_overall_score, :level_mid_plus, score: 3)
-    create(:user, :with_overall_score, :level_mid_plus, score: 1)
-    create(:user, :with_overall_score, :level_senior, score: 7)
-    create(:user, :with_overall_score, :level_senior, score: 8)
-    create(:user, :with_overall_score, :level_senior_plus, score: 9)
-    create(:user, :with_overall_score, :level_senior_plus, score: 9)
-  end
-
   describe 'Search filter' do
     context 'as admin user' do
       before do
@@ -35,9 +18,9 @@ describe 'Dashboard', type: :feature do
 
       it 'have user options' do
         within '#user_id_input' do
-          user1_option = "#{user.name.titleize} - #{user.email} - #{user.level.humanize} -"\
+          user1_option = "#{user.name.titleize} - #{user.email} -"\
                         " #{user.office} - Não Alocado"
-          user2_option = "#{user2.name.titleize} - #{user2.email} - #{user2.level.humanize} -"\
+          user2_option = "#{user2.name.titleize} - #{user2.email} -"\
                         " #{user2.office} - Não Alocado"
 
           expect(page).to have_text(user1_option) &
@@ -70,77 +53,6 @@ describe 'Dashboard', type: :feature do
       it 'do not render' do
         within '#active_admin_content' do
           expect(page).to_not have_text('Campos de Busca')
-        end
-      end
-    end
-  end
-
-  describe 'Score average' do
-    context 'as admin user' do
-      before do
-        sign_in(admin_user)
-        visit '/admin/dashboard'
-      end
-
-      it 'have trainee average' do
-        row = find("tr", text: "Intern")
-        within row do
-          expect(page).to have_text(5.5)
-        end
-      end
-
-      it 'have junior average' do
-        row = find("tr", text: /Junior [0-9]+/)
-        within row do
-          expect(page).to have_text(8)
-        end
-      end
-
-      it 'have junior_plus average' do
-        row = find("tr", text: "Junior plus")
-        within row do
-          expect(page).to have_text(3)
-        end
-      end
-
-      it 'have mid average' do
-        row = find("tr", text: /Mid [0-9]+/)
-        within row do
-          expect(page).to have_text(7)
-        end
-      end
-
-      it 'have mid_plus average' do
-        row = find("tr", text: "Mid plus")
-        within row do
-          expect(page).to have_text(2)
-        end
-      end
-
-      it 'have senior average' do
-        row = find("tr", text: /Senior [0-9]+/)
-        within row do
-          expect(page).to have_text(7.5)
-        end
-      end
-
-      it 'have senior_plus average' do
-        row = find("tr", text: "Senior plus")
-        within row do
-          expect(page).to have_text(9)
-        end
-      end
-    end
-
-    context 'as open source manager user' do
-      before do
-        sign_in(open_source_manager_user)
-        visit '/admin/dashboard'
-      end
-
-      it 'do not render' do
-        within '#active_admin_content' do
-          expect(page).to_not have_text('Média De Engenheiros Por Nível')
         end
       end
     end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -127,7 +127,6 @@ describe 'Users', type: :feature do
         find('#user_city_id').find(:option, city.name).select_option
         choose('Engenheiro')
         find('#user_specialty').find(:option, 'Backend').select_option
-        find('#user_level').find(:option, 'Junior').select_option
         find('#user_contract_type').find(:option, 'Estagiário').select_option
         find('#user_contract_company_country').find(:option, 'Brasil').select_option
         check('Ativo')
@@ -142,21 +141,18 @@ describe 'Users', type: :feature do
                         have_text(office.city) &
                         have_text('Engenheiro') &
                         have_text('Backend') &
-                        have_text('Junior') &
                         have_text('Estagiário') &
                         have_text('Admin') &
                         have_css('.row-active td', text: 'Sim') &
                         have_text('Observation')
       end
 
-      it "must deactivate User specialty and level when 'administrative' occupation is selected", js: true do
+      it "must deactivate User specialty when 'administrative' occupation is selected", js: true do
         find('#user_specialty').find(:option, 'Backend').select_option
-        find('#user_level').find(:option, 'Junior').select_option
 
         choose('Administrativo')
 
-        expect(page).to have_select('user_specialty', disabled: true, selected: '') &
-                        have_select('user_level', disabled: true, selected: '')
+        expect(page).to have_select('user_specialty', disabled: true, selected: '')
       end
     end
 
@@ -218,7 +214,6 @@ describe 'Users', type: :feature do
                             have_css('.row-performance_score td', text: user.performance_score) &
                             have_css('.row-occupation td', text: user.occupation_text) &
                             have_css('.row-specialty td', text: user.specialty.humanize) &
-                            have_css('.row-level td', text: user.level.humanize) &
                             have_css('.row-contract_type td', text: user.contract_type_text) &
                             have_css('.row-roles td', text: UserDecorator.new(user).roles_text) &
                             have_css('.row-observation td', text: user.observation)

--- a/spec/features/evaluations/index.html.erb_spec.rb
+++ b/spec/features/evaluations/index.html.erb_spec.rb
@@ -18,10 +18,9 @@ describe "Visit Evaluations", type: :feature do
     expect(page).to have_css 'table'
   end
 
-  it 'finds fields "Name", "Level", Office", "Last Performance Evaluation", "Last Performance Evaluation score", "Last English Evaluation", "Last English Level" and "Evaluate" on table' do
+  it 'finds fields "Name", Office", "Last Performance Evaluation", "Last Performance Evaluation score", "Last English Evaluation", "Last English Level" and "Evaluate" on table' do
     within 'table' do
       expect(page).to have_text('Name') &
-                      have_text('Level') &
                       have_text('Office') &
                       have_text('Last Performance Evaluation') &
                       have_text('Last Performance Evaluation Score') &

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,18 +47,9 @@ RSpec.describe User, type: :model do
     context 'when user is engineer' do
       subject { build :user, occupation: 'engineer'}
 
-      context 'level validation' do
-        it { is_expected.to validate_presence_of(:level) }
-      end
-
       context 'github validation' do
         it { is_expected.to validate_uniqueness_of(:github) }
       end
-    end
-
-    context 'when user is engineer with no level' do
-      subject { build :user, occupation: 'engineer', level: '' }
-      it { is_expected.to be_invalid }
     end
   end
 
@@ -96,18 +87,6 @@ RSpec.describe User, type: :model do
                                                   devops: 2,
                                                   mobile: 4,
                                                   qa: 5) }
-  end
-
-  describe "level" do
-    it { is_expected.to enumerize(:level).in( intern: 0,
-                                              junior: 1,
-                                              junior_plus: 2,
-                                              mid: 3,
-                                              mid_plus: 4,
-                                              senior: 5,
-                                              senior_plus: 6,
-                                              trainee: 7) }
-
   end
 
   describe 'contract type' do

--- a/spec/spreadsheets/users_spreadsheet_spec.rb
+++ b/spec/spreadsheets/users_spreadsheet_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe UsersSpreadsheet do
     %w[
       name
       email
-      level
       office
       roles
       specialty
@@ -28,7 +27,6 @@ RSpec.describe UsersSpreadsheet do
     [
       user.name,
       user.email,
-      user.level_text,
       user.office.city,
       user.roles_text,
       user.specialty_text,


### PR DESCRIPTION
This PR removes the level attribute from user. Since there is frontend level and backend level, this attribute is no longer necessary. 

Issue #537 

Main changes in the UI: 

<img width="1678" alt="Captura de Tela 2023-10-05 às 11 14 07" src="https://github.com/Codeminer42/Punchclock/assets/75209689/820fdd78-5e72-46c9-ad9f-154b10d9ca84">

<img width="1601" alt="Captura de Tela 2023-10-05 às 11 15 54" src="https://github.com/Codeminer42/Punchclock/assets/75209689/19f1a6a3-c483-4fb3-a0e7-39b965e42d76">

<img width="1680" alt="Captura de Tela 2023-10-05 às 11 16 32" src="https://github.com/Codeminer42/Punchclock/assets/75209689/134ef19b-73a8-4608-9f7b-780044ca97a5">

<img width="1657" alt="Captura de Tela 2023-10-04 às 17 00 14" src="https://github.com/Codeminer42/Punchclock/assets/75209689/82b2c9da-0098-4b65-b43a-cd36afc16f8f">

