### PR TITLE
feat: add description column

### DIFF
--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -13,6 +13,7 @@
                 <th><%= t('contributions.pr_link') %></th>
                 <th><%= t('contributions.created_at') %></th>
                 <th><%= t('contributions.pr_state') %></th>
+                <th><%= t('contributions.description') %></th>
                 <th></th>
               </tr>
             </thead>
@@ -27,6 +28,7 @@
                   <td><%= link_to contribution.link, contribution.link, target: :blank %></td>
                   <td><%= I18n.l(contribution.created_at.to_date, format: :default) %></td>
                   <td><%= contribution.pr_state.nil? ? '-' : contribution.pr_state_text %></td>
+                  <td><%= contribution.description.present? ? t('contributions.description_filled') : '-' %></td>
                   <td>
                     <%=
                       link_to image_tag('edit.png', class: 'mx-auto'),

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -22,13 +22,15 @@ pt-BR:
     created_at: 'Criada em'
     pr_state: 'Estado da PR'
     no_prs_found: 'Nenhuma PR encontrada'
+    description_filled: 'Preenchida'
+    description: 'Descrição'
   evaluations:
     written:
       add_review: 'Adicionar Revisão'
     form:
       submit: 'Salvar Revisão'
   notification_mailer:
-    subject: 
+    subject:
       notify_fill_contribution_description_html: 'Punchlock - Contribuições Aguardando Descrição'
     body_html: |
       <p>


### PR DESCRIPTION
Closes #546 

add description column to contributions list so a user can see which PRs needs description.

![image](https://github.com/Codeminer42/Punchclock/assets/92229784/42258c27-2c5d-4c76-992e-4f4196a57027)

Co-authored: @jonathanrib3 