### PR TITLE
Showing all of the users prs

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -4,7 +4,7 @@ class ContributionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @user_contributions = scopped_contributions.approved.order(created_at: :desc)
+    @user_contributions = scopped_contributions.order(created_at: :desc)
   end
 
   def edit

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -4,7 +4,7 @@ class ContributionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @user_contributions = scopped_contributions.order(created_at: :desc)
+    @user_contributions = scopped_contributions.where(state: ['received', 'approved']).order(created_at: :desc)
   end
 
   def edit

--- a/spec/controllers/contributions_controller_spec.rb
+++ b/spec/controllers/contributions_controller_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ContributionsController, type: :controller do
   let!(:contribution_list) do
     [
       create(:contribution, user:, created_at: 10.days.ago, state: :approved),
-      create(:contribution, user:, created_at: Date.today, state: :approved)
+      create(:contribution, user:, created_at: Date.today, state: :approved),
+      create(:contribution, user:, created_at: Date.today, state: :refused, rejected_reason: :other_reason)
     ]
   end
   let(:page) { Capybara::Node::Simple.new(response.body) }
@@ -54,6 +55,13 @@ RSpec.describe ContributionsController, type: :controller do
                                     .and have_content(contribution_list[1].pr_state_text)
                                     .and have_content(contribution_list[1].created_at.strftime('%d/%m/%Y'))
                                     .and have_selector(:css, "a[href='/contributions/#{contribution_list[1].id}/edit']")
+        end
+
+        it 'does not show rejected contributions' do
+          get :index
+
+
+          expect(page.find('table')).not_to have_content(contribution_list[2].link)
         end
 
         it 'returns the newest contributions first' do


### PR DESCRIPTION
This PR solves issue #549, which is to show all of the users pull requests instead of just the approved ones. 