### PR TITLE
Inaccurate Future Punch Display in Calendar UI Despite Alert Notification

### DIFF
--- a/app/javascript/packs/reducers/calendarReducer.js
+++ b/app/javascript/packs/reducers/calendarReducer.js
@@ -150,6 +150,7 @@ export default (state = initialState, action) => {
     case SHEETS_SAVE_FAIL:
       return {
         ...state,
+        sheets: emptyMap,
       };
     default:
       return state;


### PR DESCRIPTION
Closes #541

#### Changes Included
- sets dashboard's sheets to an empty map if it fails to create them.

#### Attachments
![punch](https://github.com/Codeminer42/Punchclock/assets/45002716/9cf0bb1a-73cf-415a-9dd0-01ebc01ad939)
