### PR TITLE
feat: add hourly rates sorts and filters on /admin/contributions

### DIFF
--- a/app/admin/allocations.rb
+++ b/app/admin/allocations.rb
@@ -13,13 +13,14 @@ ActiveAdmin.register Allocation do
   filter :ongoing
   filter :user, collection: -> { User.active.order(:name) }
   filter :project, collection: -> { Project.active.order(:name) }
+  filter :hourly_rate_currency, collection: -> { Allocation.hourly_rate_currencies }, as: :select
   filter :start_at
   filter :end_at
 
   index download_links: [:xlsx] do
     column :user, sortable: 'users.name'
     column :project
-    column :hourly_rate
+    column :hourly_rate, sortable: :hourly_rate_cents
     column :start_at, sortable: false
     column :end_at, sortable: false
     column :days_left, &:days_until_finish

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -23,9 +23,7 @@ class Allocation < ApplicationRecord
   scope :ongoing, -> {
     where(ongoing: true, user_id: User.active).order(start_at: :desc)
   }
-  scope :hourly_rate_currencies, -> {
-    select(:hourly_rate_currency).distinct.map(&:hourly_rate_currency)
-  }
+
   scope :finished, -> {
     where(ongoing: false, user_id: User.active).order(end_at: :desc) }
   scope :in_period, -> (start_at, end_at) do
@@ -46,6 +44,10 @@ class Allocation < ApplicationRecord
     else
       I18n.t('finished')
     end
+  end
+
+  def self.hourly_rate_currencies
+    select(:hourly_rate_currency).distinct.pluck(:hourly_rate_currency)
   end
 
   def user_punches

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -23,6 +23,9 @@ class Allocation < ApplicationRecord
   scope :ongoing, -> {
     where(ongoing: true, user_id: User.active).order(start_at: :desc)
   }
+  scope :hourly_rate_currencies, -> {
+    select(:hourly_rate_currency).distinct.map(&:hourly_rate_currency)
+  }
   scope :finished, -> {
     where(ongoing: false, user_id: User.active).order(end_at: :desc) }
   scope :in_period, -> (start_at, end_at) do

--- a/spec/features/admin/allocations_spec.rb
+++ b/spec/features/admin/allocations_spec.rb
@@ -55,7 +55,7 @@ describe 'Admin Allocation', type: :feature do
 
     it 'by hourly rates currencies' do
       within '#filters_sidebar_section' do
-        expect(page).to have_select('Moeda da taxa horária', options: Allocation.hourly_rate_currencies)
+        expect(page).to have_select('Moeda da taxa horária', options: Allocation.hourly_rate_currencies << 'Qualquer')
       end
     end
   end

--- a/spec/features/admin/allocations_spec.rb
+++ b/spec/features/admin/allocations_spec.rb
@@ -52,6 +52,12 @@ describe 'Admin Allocation', type: :feature do
         expect(page).to have_select('Projeto', options: Project.all.pluck(:name) << 'Qualquer')
       end
     end
+
+    it 'by hourly rates currencies' do
+      within '#filters_sidebar_section' do
+        expect(page).to have_select('Moeda da taxa horária', options: Allocation.hourly_rate_currencies)
+      end
+    end
   end
 
   describe 'Actions' do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -133,16 +133,8 @@ RSpec.describe Allocation, type: :model do
     let!(:brl_allocations) { create_list(:allocation, 2, hourly_rate_currency: 'BRL') }
     let!(:usd_allocation) { create(:allocation, hourly_rate_currency: 'USD') }
 
-    subject { described_class.hourly_rate_currencies }
-
-
     it 'gets the available currencies from allocations without duplicates in ASC order' do
-      expect(subject).to eq (
-        [ 
-          usd_allocation.hourly_rate_currency,
-          brl_allocations.first.hourly_rate_currency
-        ].uniq.sort_by { |currency| currency }
-      )
+      expect(described_class.hourly_rate_currencies).to eq ['BRL', 'USD']
     end
   end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -128,4 +128,21 @@ RSpec.describe Allocation, type: :model do
       end
     end
   end
+
+  describe '#hourly_rate_currencies' do
+    let!(:brl_allocations) { create_list(:allocation, 2, hourly_rate_currency: 'BRL') }
+    let!(:usd_allocation) { create(:allocation, hourly_rate_currency: 'USD') }
+
+    subject { described_class.hourly_rate_currencies }
+
+
+    it 'gets the available currencies from allocations without duplicates in ASC order' do
+      expect(subject).to eq (
+        [ 
+          usd_allocation.hourly_rate_currency,
+          brl_allocations.first.hourly_rate_currency
+        ].uniq.sort_by { |currency| currency }
+      )
+    end
+  end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Allocation, type: :model do
     end
   end
 
-  describe '#hourly_rate_currencies' do
+  describe '.hourly_rate_currencies' do
     let!(:brl_allocations) { create_list(:allocation, 2, hourly_rate_currency: 'BRL') }
     let!(:usd_allocation) { create(:allocation, hourly_rate_currency: 'USD') }
 


### PR DESCRIPTION
### Problem

Closes #576 - Adjustments on ActiveAdmin Allocations' index page

### Solution

To make the hourly rates sorting work i decided to sort allocations through their value as cents - `hourly_rate_cents` and used ActiveAdmin's `sortable` property on the table structure. 

To make the hourly rates currencies filter work i added a scope that gets all available currencies from allocations table without any duplicates in ascending order, being that they're rendered through an ActiveAdmin `filter` as a select. 

A demo of how things are working right now:

![demo-576](https://github.com/Codeminer42/Punchclock/assets/50427117/ba41a980-37ae-4c65-ae89-f9388345618b)
