### PR TITLE
Adding configs to sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,3 +6,17 @@ if Rails.env.production?
     username == ENV["SIDEKIQ_USERNAME"] && password == ENV["SIDEKIQ_PASSWORD"]
   end
 end
+
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV[ENV["REDIS_PROVIDER"]],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV[ENV["REDIS_PROVIDER"]],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end


### PR DESCRIPTION
This PR solves the problem of sidekiq in production, by adding [these](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-from-sidekiq) configs. 