### PR TITLE
feat: add hourly rates to allocations table on /admin/users page

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -130,6 +130,9 @@ ActiveAdmin.register User do
               column :project_name do |allocation|
                 allocation.project.name
               end
+              column :hourly_rate do |allocation|
+                allocation.decorate.hourly_rate
+              end
               column :start_at
               column :end_at
               column :ongoing

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -126,12 +126,12 @@ ActiveAdmin.register User do
         attributes_table do
           row :current_allocation
           row :allocations do
-            table_for user.allocations.order(start_at: :desc) do
+            table_for user.allocations.order(start_at: :desc), i18n: Allocation do
               column :project_name do |allocation|
                 allocation.project.name
               end
               column :hourly_rate do |allocation|
-                allocation.decorate.hourly_rate
+                allocation.hourly_rate
               end
               column :start_at
               column :end_at

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -2,6 +2,7 @@
 
 class UserDecorator < Draper::Decorator
   delegate_all
+  decorates_association :allocations
 
   def current_allocation
     super || ENV["DEFAULT_PROJECT_NAME"] || I18n.t('not_allocated')

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -239,6 +239,38 @@ describe 'Users', type: :feature do
             expect(page).to have_css('.row-allocations tbody tr', count: 1)
           end
         end
+
+        context 'on allocations table' do 
+          it 'finds user allocation project name' do 
+            within '#alocacoes' do
+              expect(page).to have_text(user.allocations.first.project.name)
+            end
+          end
+
+          it 'finds user allocation hourly rate' do 
+            within '#alocacoes' do
+              expect(page).to have_text(user.allocations.first.decorate.hourly_rate)
+            end
+          end
+
+          it 'finds user allocation start date' do 
+            within '#alocacoes' do
+              expect(page).to have_text(I18n.l(user.allocations.first.start_at, format: :long))
+            end
+          end
+
+          it 'finds user allocation end date' do 
+            within '#alocacoes' do
+              expect(page).to have_text(I18n.l(user.allocations.first.end_at, format: :long))
+            end
+          end
+
+          it 'finds user allocation ongoing status' do 
+            within '#alocacoes' do
+              expect(page).to have_text('Sim')
+            end
+          end
+        end
       end
 
       context 'on Performance Evaluations tab' do


### PR DESCRIPTION
### Problem

**Closes issue**  #577 - Add hourly rate column to allocations table

### Solution

To solve this, I simply added on admin User's code base a column named `hourly rate`. The values in that column are going to be rendered using Allocation's Decorator, which already has a function that formats the hourly rate with their right currency symbol and amount.

Here's the result:

![image](https://github.com/Codeminer42/Punchclock/assets/50427117/6ae82df8-38b0-4337-bb89-90e05c664720)