### PR TITLE
feat: talks index page

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -5,6 +5,8 @@ class TalksController < ApplicationController
     @talks = scoped_talks.page(params[:page])
   end
 
+  private
+
   def scoped_talks
     current_user.talks
   end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,0 +1,11 @@
+class TalksController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @talks = scoped_talks.page(params[:page])
+  end
+
+  def scoped_talks
+    current_user.talks
+  end
+end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -2,12 +2,6 @@ class TalksController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @talks = scoped_talks.page(params[:page])
-  end
-
-  private
-
-  def scoped_talks
-    current_user.talks
+    @talks = current_user.talks.page(params[:page])
   end
 end

--- a/app/views/talks/_table.html.erb
+++ b/app/views/talks/_table.html.erb
@@ -1,0 +1,31 @@
+<table class="table table-hover table-bordered">
+  <thead>
+    <tr>
+      <th><%= Talk.human_attribute_name(:event_name) %></th>
+      <th><%= Talk.human_attribute_name(:talk_title) %></th>
+      <th><%= Talk.human_attribute_name(:date) %></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% if talks.any? %>
+      <% talks.each do |talk| %>
+        <tr>
+          <td><%= talk.event_name %></td>
+          <td><%= talk.talk_title %></td>
+          <td><%= talk.date %></td>
+          <td><%= image_tag('edit.png', class: 'mx-auto') %></td>
+          <td><%= image_tag('destroy.png', class: 'mx-auto') %></td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr>
+        <td colspan="3">
+          <%= t('talks.no_talks_found') %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/talks/_table.html.erb
+++ b/app/views/talks/_table.html.erb
@@ -22,7 +22,7 @@
       <% end %>
     <% else %>
       <tr>
-        <td colspan="3">
+        <td colspan="5">
           <%= t('talks.no_talks_found') %>
         </td>
       </tr>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="container-fluid home">
+    <div class="card mb-3">
+      <div class="card-header">
+        <%= t('talks.title') %>
+      </div>
+      <div class="card-body">
+        <div class="table-responsive ">
+          <%= render 'table', talks: @talks %>
+        </div>
+      </div>
+      <div>
+        <%= paginate @talks %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/config/locales/pt-BR/views.yml
+++ b/config/locales/pt-BR/views.yml
@@ -29,6 +29,9 @@ pt-BR:
       add_review: 'Adicionar Revisão'
     form:
       submit: 'Salvar Revisão'
+  talks:
+    title: 'Minhas Palestras'
+    no_talks_found: 'Nenhuma palestra encontrada'
   notification_mailer:
     subject:
       notify_fill_contribution_description_html: 'Punchlock - Contribuições Aguardando Descrição'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq'
 
   resources :professional_experiences
+  resources :talks, only: %i[index]
 
   get '/admin/vacations/:id/denied', to: 'admin/vacations#denied', as: :admin_vacations_denied
   get '/admin/vacations/:id/approve', to: 'admin/vacations#approve', as: :admin_vacations_approve

--- a/spec/features/index_talks_spec.rb
+++ b/spec/features/index_talks_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Talks Index page', type: :feature do
+  describe 'GET index' do
+    context 'when the user has saved talks' do
+      let!(:user) { create(:user) }
+      let!(:talks) { create_list(:talk, 2, user:) }
+
+      before do
+        sign_in user
+        visit '/talks'
+      end
+
+      it 'renders Talks table with Event Name, Talk Title and Date attributes' do
+        within('.card-body') do
+          expect(page).to have_text('Nome do evento') &
+                          have_text('Título da palestra') &
+                          have_text('Data')
+        end
+      end
+
+      context 'on Talks table' do
+        it 'finds user talks event names' do
+          within('.card-body') do
+            expect(page).to have_text(talks.first.event_name) &
+                            have_text(talks.last.event_name)
+          end
+        end
+        it 'finds user talks titles' do
+          within('.card-body') do
+            expect(page).to have_text(talks.first.talk_title) &
+                            have_text(talks.last.talk_title)
+          end
+        end
+        it 'finds user talks dates' do
+          within('.card-body') do
+            expect(page).to have_text(talks.first.date) &
+                            have_text(talks.last.date)
+          end
+        end
+      end
+    end
+
+    context 'when the user has no saved talk' do
+      let!(:user) { create(:user) }
+
+      before do
+        sign_in user
+        visit '/talks'
+      end
+
+      it 'renders Talks table with Event Name, Talk Title and Date attributes' do
+        within('.card-body') do
+          expect(page).to have_text('Nome do evento') &
+                          have_text('Título da palestra') &
+                          have_text('Data')
+        end
+      end
+
+      context 'on Talks table' do
+        it 'finds message saying that no talks were found' do
+          within('.card-body') do
+            expect(page).to have_text(I18n.t('talks.no_talks_found'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/index_talks_spec.rb
+++ b/spec/features/index_talks_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe 'Talks Index page', type: :feature do
 
     context 'when the user has no saved talk' do
       let!(:user) { create(:user) }
+      let!(:another_user) { create(:user) }
+      let!(:talks) { create_list(:talk, 2, user: another_user) }
 
       before do
         sign_in user

--- a/spec/requests/talks_controller_spec.rb
+++ b/spec/requests/talks_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe TalksController, type: :request do
+  describe 'GET index' do
+    context 'when user is authenticated' do
+      let(:user) { create(:user) }
+      let(:talk_list) { create_list(:talk, user:) }
+
+      before do
+        sign_in user
+        get :index
+      end
+
+      it 'renders the index template' do
+        expect(response).to render_template(:index)
+      end
+
+      it 'has http status 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders current user talks' do 
+      end
+    end
+
+    context 'when user is not authenticated' do
+      before do
+        get :index
+      end
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/talks_controller_spec.rb
+++ b/spec/requests/talks_controller_spec.rb
@@ -3,29 +3,27 @@ require 'rails_helper'
 RSpec.describe TalksController, type: :request do
   describe 'GET index' do
     context 'when user is authenticated' do
-      let(:user) { create(:user) }
-      let(:talk_list) { create_list(:talk, user:) }
+      let!(:user) { create(:user) }
+      let!(:talk_list) { create_list(:talk, 2, user:) }
 
       before do
         sign_in user
-        get :index
       end
 
       it 'renders the index template' do
+        get talks_path
         expect(response).to render_template(:index)
       end
 
       it 'has http status 200' do
+        get talks_path
         expect(response).to have_http_status(:ok)
-      end
-
-      it 'renders current user talks' do 
       end
     end
 
     context 'when user is not authenticated' do
       before do
-        get :index
+        get talks_path
       end
 
       it 'redirects to sign in page' do


### PR DESCRIPTION
###Problem

**Closes Issue** #571 - Tasks index page

###Solution

To add the index page i created a controller to Talk model and created the view. The page's styled is based on /contributions page so it follows the same structure, but with pagination and without the 'go to top page' button at the bottom of the page.

This feature has feature tests too on /spec/feaetures/index_talks_spec.rb

_When the current user doesn't have saved talks_
![Screenshot from 2023-10-24 13-02-32](https://github.com/Codeminer42/Punchclock/assets/50427117/b8848c5a-c750-464f-a668-414f8fd2b2f3)

_When the current user does have saved talks_
![demo-571](https://github.com/Codeminer42/Punchclock/assets/50427117/24ab8f4c-eb9b-41e4-8177-136fe581e055)